### PR TITLE
feat(parser): allow setting descriptions for default values

### DIFF
--- a/examples/default-values.ts
+++ b/examples/default-values.ts
@@ -1,0 +1,74 @@
+// ---
+// id: default-values
+// title: Default Values
+// description: |
+//   This is a simple example that demonstrates the various ways you can set default values for options.
+//
+//   The default value can be set via the `default` property in an option definition. This can be done in three ways:
+//   - Setting the `default` property to a value directly
+//   - Setting the `default` property to an object containing function that returns a value and a description
+//   - Setting the `default` property to an object containing a value and a description
+//
+//   Setting the `default` property to a value directly is the simplest way to set a default value, but can lead to some odd behavior if the value isn't consistent. For example, if the default value is the value of an environment variable that may differ among users then the actual default value will be different for each user. In this case in documentation, it would be better to tell users a description of the default value rather than the actual value.
+//
+// commands:
+//  - '{filename}'
+//  - '{filename} --name sir'
+//  - '{filename} --greeting "Good day"'
+//  - command: '{filename} --farewell "Goodbye"'
+//    env:
+//      DEFAULT_VALUES_HELLO: "Greetings"
+// ---
+import cliForge from 'cli-forge';
+
+const cli = cliForge('default-values').command('$0', {
+  builder: (args) =>
+    args
+      .option('name', {
+        type: 'string',
+        description: 'The name to say hello to',
+        // Setting the default value directly
+        default: 'World',
+      })
+      .option('greeting', {
+        type: 'string',
+        description: 'The greeting to use',
+        // Setting the default value to an object containing a value and a description
+        default: {
+          // The value here may be different across command runs. In docs,
+          // we want a consistent description of the default value.
+          value: process.env['DEFAULT_VALUES_HELLO'] ?? 'Hello',
+          description: 'The default greeting',
+        },
+      })
+      .option('farewell', {
+        type: 'string',
+        description: 'The farewell to use',
+        // Setting the default value to an object containing a function that returns a value and a description
+        default: {
+          // The value here may be different across command runs. In docs,
+          // we want a consistent description of the default. Using a factory function
+          // gives more flexibility compared to the value + description method above.
+          factory: () => {
+            if (process.arch === 'x64') {
+              return 'Goodbye';
+            } else {
+              return 'Goodnight';
+            }
+          },
+          description: 'The default farewell',
+        },
+      }),
+  handler: (args) => {
+    console.log(`${args.greeting}, ${args.name}!`);
+    console.log(`${args.farewell}, ${args.name}!`);
+  },
+});
+
+export default cli;
+
+if (require.main === module) {
+  (async () => {
+    await cli.forge();
+  })();
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/parser';
 export * from './lib/utils/case-transformations';
 export * from './lib/helpers';
 export * from './lib/option-types';
+export * from './lib/utils/read-default-value';

--- a/packages/parser/src/lib/option-types/common.ts
+++ b/packages/parser/src/lib/option-types/common.ts
@@ -1,3 +1,18 @@
+export type PlainDefaultValue<T> = T;
+export type DefaultValueWithDescription<T> = {
+  value: PlainDefaultValue<T>;
+  description: string;
+};
+export type DefaultValueWithFactory<T> = {
+  factory: () => PlainDefaultValue<T>;
+  description: string;
+};
+
+export type Default<T> =
+  | PlainDefaultValue<T>
+  | DefaultValueWithDescription<T>
+  | DefaultValueWithFactory<T>;
+
 export type CommonOptionConfig<T, TCoerce = T, TChoices = T[]> = {
   /**
    * If set to true, the option will be treated as a positional argument.
@@ -16,8 +31,10 @@ export type CommonOptionConfig<T, TCoerce = T, TChoices = T[]> = {
 
   /**
    * Provide a default value for the option.
+   *
+   * If the default value is a tuple, the first value will be used as the default value, and the second value will be used as the description.
    */
-  default?: T;
+  default?: Default<T>;
 
   /**
    * Provide a description for the option.

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -7,6 +7,7 @@ import { parserMap } from './parsers/parser-map';
 import { NoValueError, Parser, ParserContext } from './parsers/typings';
 import { getConfiguredOptionKey } from './utils/get-configured-key';
 import { isFlag, isNextFlag, readArgKeys } from './utils/flags';
+import { readDefaultValue } from './utils/read-default-value';
 
 /**
  * Base type for parsed arguments.
@@ -290,7 +291,7 @@ export class ArgvParser<
           }
         }
         if (configuration.default !== undefined) {
-          normalized[configuration.key] ??= configuration.default;
+          normalized[configuration.key] ??= readDefaultValue(configuration)[0];
         }
       }
     }
@@ -544,7 +545,7 @@ export function tryParseValue(
   } catch (e) {
     if (e instanceof NoValueError) {
       if (input.config.default !== undefined) {
-        return input.config.default;
+        return readDefaultValue(input.config)[0];
       }
       throw new Error(`Expected a value for ${input.config.key}`);
     }

--- a/packages/parser/src/lib/utils/read-default-value.spec.ts
+++ b/packages/parser/src/lib/utils/read-default-value.spec.ts
@@ -1,0 +1,32 @@
+import { readDefaultValue } from './read-default-value';
+describe('readDefaultValue', () => {
+  it('should return the default value if no description provided', () => {
+    const val = readDefaultValue({
+      type: 'string',
+      default: 'default',
+    });
+    expect(val).toEqual(['default', undefined]);
+  });
+
+  it('should return the default value with description', () => {
+    const val = readDefaultValue({
+      type: 'string',
+      default: {
+        value: 'default',
+        description: 'description',
+      },
+    });
+    expect(val).toEqual(['default', 'description']);
+  });
+
+  it('should return the default value with description from factory', () => {
+    const val = readDefaultValue({
+      type: 'string',
+      default: {
+        factory: () => 'default',
+        description: 'description',
+      },
+    });
+    expect(val).toEqual(['default', 'description']);
+  });
+});

--- a/packages/parser/src/lib/utils/read-default-value.ts
+++ b/packages/parser/src/lib/utils/read-default-value.ts
@@ -1,0 +1,28 @@
+import {
+  Default,
+  OptionConfig,
+  PlainDefaultValue,
+  OptionConfigToType,
+} from '../option-types';
+
+export function readDefaultValue<const T extends OptionConfig>(
+  option: T
+): [OptionConfigToType<T> | undefined, string | undefined] {
+  if (option.default !== undefined) {
+    const declaredDefault = option.default as any as Default<T>;
+    if (typeof declaredDefault === 'object') {
+      if ('value' in declaredDefault) {
+        const value = declaredDefault.value as any as OptionConfigToType<T>;
+        return [value, declaredDefault.description];
+      }
+      if ('factory' in declaredDefault) {
+        const factory =
+          declaredDefault.factory as any as () => OptionConfigToType<T>;
+        return [factory(), declaredDefault.description];
+      }
+    } else {
+      return [declaredDefault, undefined];
+    }
+  }
+  return [undefined, undefined];
+}


### PR DESCRIPTION
Expands default value support to allow describing the default in cases where it may vary. See example.