### PR TITLE
fix(parser): only consume 'true'/'false' as boolean flag values and other misc changes

### DIFF
--- a/docs/plans/2026-02-12-positional-args-with-subcommands-design.md
+++ b/docs/plans/2026-02-12-positional-args-with-subcommands-design.md
@@ -1,0 +1,45 @@
+# Positional Arguments with Subcommands
+
+## Problem
+
+When a command has both positional arguments and subcommands (e.g. `$0 [file] <lint|test>`), the parser greedily consumes non-flag tokens as positional arguments before the `unmatchedParser` callback can identify subcommands. This means `$0 lint` assigns `"lint"` to the `file` positional instead of dispatching to the `lint` subcommand.
+
+## Root Cause
+
+In `parser.ts`, the non-flag token handling checks `configuredPositionals[matchedPositionals]` first. If a positional config exists, the token is consumed immediately — `unmatchedParser` is never consulted.
+
+```
+non-flag token arrives
+  → positional config exists? → consume as positional (GREEDY)
+  → no positional config? → try unmatchedParser → push to unmatched
+```
+
+## Desired Behavior
+
+Context-aware resolution: try subcommand lookup first, fall back to positional.
+
+```
+non-flag token arrives
+  → unmatchedParser recognizes it? → handle as subcommand
+  → positional config exists? → consume as positional
+  → push to unmatched
+```
+
+## Test Scenarios
+
+CLI shape: `app [file] <lint|test>`
+
+| Invocation | Expected | Currently Works? |
+|---|---|---|
+| `app lint` | Runs lint, file=undefined | No |
+| `app myfile lint` | file='myfile', runs lint | No |
+| `app lint myfile` | Runs lint, myfile in lint's args | No |
+| `app test --fix` | Runs test with --fix | No |
+| `app myfile test --fix` | file='myfile', runs test with --fix | No |
+| `app --verbose lint` | verbose=true, runs lint | Maybe |
+
+## Implementation Approach
+
+1. Add tests in `internal-cli.spec.ts` documenting current vs expected behavior
+2. Fix parser token priority: consult `unmatchedParser` before positional matching
+3. Verify all scenarios pass

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -729,6 +729,31 @@ describe('cliForge', () => {
       expect(handlerArgs).toBeDefined();
       expect(handlerArgs.env).toBe('prod');
     });
+
+    it('should work after async middleware', async () => {
+      const app = cli('foo', {
+        builder: (argv) =>
+          argv
+            .middleware(async (args) => {
+              const newPromise = new Promise((res) => setImmediate(res));
+              await newPromise;
+              (args as any)['middleware-ran'] = true;
+            })
+            .init((cli) => {
+              cli.option('bar', {
+                type: 'boolean',
+              });
+            }),
+      });
+      const parsed = await app.forge(['--bar']);
+      expect(parsed).toMatchInlineSnapshot(`
+        {
+          "bar": true,
+          "middleware-ran": true,
+          "unmatched": [],
+        }
+      `);
+    });
   });
 
   describe('subcommand init hooks', () => {
@@ -1060,6 +1085,117 @@ describe('cliForge', () => {
 
       expect(handlerArgs.verbose).toBe(false);
       expect(handlerArgs.config).toBe('default.json');
+    });
+  });
+
+  describe('positional arguments with subcommands', () => {
+    // CLI shape: app [file] <lint|test>
+    // The parser tries subcommand lookup (via unmatchedParser) before
+    // consuming tokens as positional arguments. This allows subcommand
+    // names to take priority, with non-matching tokens falling through
+    // to positional matching.
+
+    function buildTestCli() {
+      return cli('app')
+        .positional('file', { type: 'string' })
+        .command('lint', {
+          builder: (cmd) =>
+            cmd.option('fix', { type: 'boolean', default: false }),
+          handler: (args) => args,
+        })
+        .command('test', {
+          builder: (cmd) =>
+            cmd.option('watch', { type: 'boolean', default: false }),
+          handler: (args) => args,
+        });
+    }
+
+    it('should run subcommand when only subcommand name is given: `app lint`', async () => {
+      // `app lint` → 'lint' recognized as subcommand, file stays undefined
+      const result = (await buildTestCli().forge(['lint'])) as any;
+      expect(result.file).toBeUndefined();
+      expect(result.fix).toBe(false);
+    });
+
+    it('should run subcommand when positional follows it: `app lint myfile`', async () => {
+      // `app lint myfile` → 'lint' recognized as subcommand,
+      // 'myfile' consumed as file positional
+      const result = (await buildTestCli().forge([
+        'lint',
+        'myfile',
+      ])) as any;
+      expect(result.file).toBe('myfile');
+      expect(result.fix).toBe(false);
+    });
+
+    it('should run subcommand with its own flags: `app test --watch`', async () => {
+      // `app test --watch` → 'test' recognized as subcommand,
+      // --watch parsed by the test subcommand
+      const result = (await buildTestCli().forge([
+        'test',
+        '--watch',
+      ])) as any;
+      expect(result.watch).toBe(true);
+      expect(result.file).toBeUndefined();
+    });
+
+    it('should run subcommand when string flags precede it: `app --config x lint`', async () => {
+      // `app --config x lint` → --config parsed as flag consuming 'x',
+      // 'lint' recognized as subcommand (not consumed by positional)
+      const result = (await cli('app')
+        .option('config', { type: 'string' })
+        .positional('file', { type: 'string' })
+        .command('lint', {
+          builder: (cmd) =>
+            cmd.option('fix', { type: 'boolean', default: false }),
+          handler: (args) => args,
+        })
+        .forge(['--config', 'app.json', 'lint'])) as any;
+
+      expect(result.config).toBe('app.json');
+      expect(result.fix).toBe(false);
+      expect(result.file).toBeUndefined();
+    });
+
+    it('should run subcommand when boolean flags precede it: `app --verbose lint`', async () => {
+      // `app --verbose lint` → --verbose set to true (no value consumed),
+      // 'lint' recognized as subcommand
+      const result = (await cli('app')
+        .option('verbose', { type: 'boolean', default: false })
+        .positional('file', { type: 'string' })
+        .command('lint', {
+          builder: (cmd) =>
+            cmd.option('fix', { type: 'boolean', default: false }),
+          handler: (args) => args,
+        })
+        .forge(['--verbose', 'lint'])) as any;
+
+      expect(result.verbose).toBe(true);
+      expect(result.fix).toBe(false);
+      expect(result.file).toBeUndefined();
+    });
+
+    it('should parse positional before subcommand: `app myfile lint`', async () => {
+      // `app myfile lint` → 'myfile' not a subcommand, consumed as file,
+      // 'lint' recognized as subcommand
+      const result = (await buildTestCli().forge([
+        'myfile',
+        'lint',
+      ])) as any;
+      expect(result.file).toBe('myfile');
+      expect(result.fix).toBe(false);
+    });
+
+    it('should parse positional and subcommand with flags: `app myfile test --watch`', async () => {
+      // `app myfile test --watch` → 'myfile' consumed as file,
+      // 'test' recognized as subcommand, --watch parsed by test
+      const result = (await buildTestCli().forge([
+        'myfile',
+        'test',
+        '--watch',
+      ])) as any;
+      expect(result.file).toBe('myfile');
+      expect(result.watch).toBe(true);
     });
   });
 });

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -864,10 +864,22 @@ export class InternalCLI<
         // Non-strict parse to get current arg values for init hooks.
         // Seeded with mergedArgs so required options parsed at earlier
         // levels satisfy validation.
+        // The unmatchedParser intercepts subcommand tokens before
+        // positional matching can greedily consume them.
+        let discoveredCommand: string | null = null;
         const parsed = this.parser
           .clone({
             ...this.parser.options,
-            unmatchedParser: () => false,
+            unmatchedParser: (arg) => {
+              if (!discoveredCommand && !arg.startsWith('-')) {
+                const cmd = currentCmd.registeredCommands[arg];
+                if (cmd && cmd.configuration) {
+                  discoveredCommand = arg;
+                  return true;
+                }
+              }
+              return false;
+            },
             strict: false,
             validate: false,
           })
@@ -892,30 +904,46 @@ export class InternalCLI<
           await hook(currentCmd as any, mergedArgs);
         }
 
-        // Find the next command in unmatched tokens
-        const unmatched: string[] = parsed.unmatched ?? [];
+        // Build the next command if one was discovered during parsing
+        // (i.e., subcommand token intercepted before positional matching)
         let nextCmd: InternalCLI<any, any, any, any> | null = null;
+        if (discoveredCommand) {
+          const cmd = currentCmd.registeredCommands[discoveredCommand];
+          cmd.parser = this.parser;
+          cmd.configuration!.builder?.(cmd as any);
+          this.commandChain.push(discoveredCommand);
+          nextCmd = cmd;
+        }
+
+        // Scan unmatched tokens for commands that may have been registered
+        // dynamically by init hooks (these weren't in registeredCommands
+        // during parse, so the unmatchedParser couldn't intercept them).
+        const unmatched: string[] = parsed.unmatched ?? [];
         const remainingArgs: string[] = [];
 
-        for (const token of unmatched) {
-          if (!nextCmd && !token.startsWith('-')) {
-            const cmd = currentCmd.registeredCommands[token];
-            if (cmd && cmd.configuration) {
-              cmd.parser = this.parser;
-              cmd.configuration.builder?.(cmd as any);
-              this.commandChain.push(token);
-              nextCmd = cmd;
-              continue;
+        if (!nextCmd) {
+          for (const token of unmatched) {
+            if (!nextCmd && !token.startsWith('-')) {
+              const cmd = currentCmd.registeredCommands[token];
+              if (cmd && cmd.configuration) {
+                cmd.parser = this.parser;
+                cmd.configuration.builder?.(cmd as any);
+                this.commandChain.push(token);
+                nextCmd = cmd;
+                continue;
+              }
             }
+            remainingArgs.push(token);
           }
-          remainingArgs.push(token);
         }
 
         if (!nextCmd) {
           currentArgs = unmatched;
           break;
         }
-        currentArgs = remainingArgs;
+        // If command found during parse, all unmatched are remaining args.
+        // If command found in post-init scan, use filtered remaining args.
+        currentArgs = discoveredCommand ? unmatched : remainingArgs;
         currentCmd = nextCmd;
       }
 

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -1,5 +1,26 @@
-import { CommonOptionConfig } from './option-types/common';
+import {
+  ConfigurationProvider,
+  resolveConfiguration,
+} from './config-files/configuration-loader';
 import { hideBin } from './helpers';
+import {
+  LocalizationDictionary,
+  LocalizationFunction,
+  detectLocale,
+  resolveLocalizedText,
+} from './localization';
+import {
+  ArrayOptionConfig,
+  BooleanOptionConfig,
+  Internal,
+  InternalOptionConfig,
+  NumberOptionConfig,
+  ObjectOptionConfig,
+  OptionConfig,
+  StringOptionConfig,
+  UnknownOptionConfig,
+} from './option-types';
+import { CommonOptionConfig } from './option-types/common';
 import {
   OptionConfigToType,
   ResolveProperties,
@@ -8,33 +29,16 @@ import {
   MakeUndefinedPropertiesOptional,
   WithOptional,
 } from './option-types/type-resolution';
-import { fromDashedToCamelCase, fromCamelCaseToDashed, getEnvKey } from './utils/case-transformations';
-import {
-  Internal,
-  InternalOptionConfig,
-  ObjectOptionConfig,
-  StringOptionConfig,
-  NumberOptionConfig,
-  BooleanOptionConfig,
-  ArrayOptionConfig,
-  OptionConfig,
-  UnknownOptionConfig,
-} from './option-types';
 import { parserMap } from './parsers/parser-map';
 import { NoValueError, Parser, ParserContext } from './parsers/typings';
-import { getConfiguredOptionKey } from './utils/get-configured-key';
+import {
+  fromCamelCaseToDashed,
+  fromDashedToCamelCase,
+  getEnvKey,
+} from './utils/case-transformations';
 import { isFlag, isNextFlag, readArgKeys } from './utils/flags';
+import { getConfiguredOptionKey } from './utils/get-configured-key';
 import { readDefaultValue } from './utils/read-default-value';
-import {
-  ConfigurationProvider,
-  resolveConfiguration,
-} from './config-files/configuration-loader';
-import {
-  LocalizationDictionary,
-  LocalizationFunction,
-  detectLocale,
-  resolveLocalizedText,
-} from './localization';
 
 /**
  * Defines the option configuration passed to {@link ArgvParser.env}.
@@ -83,6 +87,8 @@ export type ParserOptions<T extends ParsedArgs = ParsedArgs> = {
 
   /**
    * Can be used to implement custom handling for unmatched arguments.
+   * This runs before positional arguments would be matched, allowing it to intercept
+   * values that would otherwise be consumed as positionals (e.g. for subcommand parsing).
    * @returns true if the argument was handled, false if it was not
    */
   unmatchedParser?: (
@@ -557,7 +563,10 @@ export class ArgvParser<
    *   run on the complete result.
    * @returns The parsed arguments
    */
-  parse(argv: string[] = hideBin(process.argv), alreadyParsed?: Record<string, unknown>) {
+  parse(
+    argv: string[] = hideBin(process.argv),
+    alreadyParsed?: Record<string, unknown>
+  ) {
     const argvClone = [...argv];
     const result: any = {
       ...alreadyParsed,
@@ -573,7 +582,10 @@ export class ArgvParser<
       // Found a flag + value
       if (isFlag(arg)) {
         const [maybeArg, maybeValue] = arg.split('=');
-        const keys = readArgKeys(maybeArg as `-${string}`, this.options.stripDashed);
+        const keys = readArgKeys(
+          maybeArg as `-${string}`,
+          this.options.stripDashed
+        );
         const configuredKeys = keys.map((key) =>
           getConfiguredOptionKey<TArgs>(key, this.configuredOptions)
         );
@@ -616,6 +628,13 @@ export class ArgvParser<
         }
         // Found a positional argument
       } else {
+        // Try unmatchedParser first (e.g., for subcommand discovery).
+        // This allows subcommand tokens to be intercepted before
+        // positional matching greedily consumes them.
+        if (this.options.unmatchedParser(arg, argvClone, this)) {
+          arg = argvClone.shift();
+          continue;
+        }
         let configuration = this.configuredPositionals[matchedPositionals];
         // Handles if a positional argument was already set by a flag.
         while (configuration && result[configuration.key] !== undefined) {
@@ -632,10 +651,6 @@ export class ArgvParser<
           result[configuration.key] = value;
           matchedPositionals++;
         } else {
-          if (this.options.unmatchedParser(arg, argvClone, this)) {
-            arg = argvClone.shift();
-            continue;
-          }
           result.unmatched.push(arg);
         }
         arg = argvClone.shift();
@@ -773,9 +788,7 @@ export class ArgvParser<
     // Validate strict mode - check for unmatched arguments
     if (this.options.strict && result.unmatched?.length) {
       for (const unmatchedArg of result.unmatched) {
-        const error = new Error(
-          `Unknown argument: ${unmatchedArg}`
-        );
+        const error = new Error(`Unknown argument: ${unmatchedArg}`);
         delete error.stack;
         errors.push(error);
       }

--- a/packages/parser/src/lib/parsers/boolean.ts
+++ b/packages/parser/src/lib/parsers/boolean.ts
@@ -1,5 +1,4 @@
 import { Internal, BooleanOptionConfig } from '../option-types';
-import { isNextFlag } from '../utils/flags';
 import { Parser } from './typings';
 
 export const booleanParser: Parser<Internal<BooleanOptionConfig>> = ({
@@ -12,13 +11,14 @@ export const booleanParser: Parser<Internal<BooleanOptionConfig>> = ({
     if (val === undefined) {
       return true;
     }
-    if (isNextFlag(val)) {
-      tokens.unshift(val);
+    if (val === 'true') {
       return true;
     }
     if (val === 'false') {
       return false;
     }
+    // Not a boolean literal — put it back for positional/subcommand handling
+    tokens.unshift(val);
     return true;
   })();
   return negated ? !parsed : parsed;


### PR DESCRIPTION
This pull request addresses a long-standing issue with how the CLI parser handles positional arguments in the presence of subcommands. Previously, the parser would greedily consume tokens as positional arguments, making it impossible to invoke subcommands without workarounds. The changes implement a context-aware approach that prioritizes subcommand detection before assigning tokens to positional arguments, and introduce comprehensive tests to verify the correct behavior. Additionally, the boolean option parser is improved to handle ambiguous values more robustly.

The most important changes are:

**Parser logic improvements:**

* The parser now checks for subcommand tokens using the `unmatchedParser` callback before matching positional arguments, allowing subcommands to take priority over positionals. (`packages/parser/src/lib/parser.ts`, `packages/cli-forge/src/lib/internal-cli.ts`) [[1]](diffhunk://#diff-a6f7f871296776d52cb5b8bff0463048d9056d2cc7e633e2b3a868bb3f24d6d2R631-R637) [[2]](diffhunk://#diff-a6f7f871296776d52cb5b8bff0463048d9056d2cc7e633e2b3a868bb3f24d6d2L635-L638) [[3]](diffhunk://#diff-03e38a147f232775d747edc13a22c09fb46794ff1c0311d437913f2b3b8995e5R867-R882) [[4]](diffhunk://#diff-03e38a147f232775d747edc13a22c09fb46794ff1c0311d437913f2b3b8995e5L895-R924) [[5]](diffhunk://#diff-03e38a147f232775d747edc13a22c09fb46794ff1c0311d437913f2b3b8995e5R938-R946)
* The boolean parser is updated so that only the literals `"true"` and `"false"` are interpreted as boolean values; other values are returned to the argument list for further processing (e.g., as positionals or subcommands). (`packages/parser/src/lib/parsers/boolean.ts`)

**Test coverage:**

* Comprehensive tests are added to verify correct behavior for all combinations of positionals, subcommands, and flags, ensuring that subcommands are recognized in all expected scenarios. (`packages/cli-forge/src/lib/internal-cli.spec.ts`)
* An additional test is added to ensure async middleware does not interfere with argument parsing. (`packages/cli-forge/src/lib/internal-cli.spec.ts`)

**Documentation:**

* A new design document is added to explain the problem, root cause, desired behavior, test scenarios, and implementation approach for positional arguments with subcommands. (`docs/plans/2026-02-12-positional-args-with-subcommands-design.md`)