### PR TITLE
feat(cli-forge): add --help and --version customization

### DIFF
--- a/docs-site/docs/guides/help-and-version.md
+++ b/docs-site/docs/guides/help-and-version.md
@@ -1,0 +1,142 @@
+---
+title: Help & Version Customization
+description: Customize or disable the built-in --help and --version flags, per-option help text, and error handling
+nav:
+  order: 8
+---
+
+# Help & version customization
+
+CLI Forge registers `--help` and `--version` flags automatically. You can customize their output, disable them entirely, control how individual options appear in help text, and customize error handling with `.catch()`.
+
+## Custom help output
+
+Pass a callback to `.help()` to take full control of the help text. The callback receives a context object you can destructure:
+
+<%= example('help-customization').region('help') %>
+
+The `HelpContext` object contains:
+
+| Property | Description |
+|---|---|
+| `args` | The parsed arguments at the time `--help` was invoked. Typed as `Partial<TArgs>` since the parse may not have completed. |
+| `cli` | The CLI instance for the command being helped. |
+| `renderDefaultHelp()` | Returns the full default help text. Call it to augment rather than replace. |
+| `options` | Array of visible options, each with a `renderHelpText()` method (see [below](#working-with-options-in-help-callbacks)). |
+
+Because `args` includes everything parsed so far, you can vary the output based on other flags — for example, showing extra detail when `--verbose` is also passed.
+
+## Custom version output
+
+Pass a callback to `.version()` for custom version formatting. The `VersionContext` object works the same way:
+
+<%= example('help-customization').region('version') %>
+
+Chain `.version(string)` before `.version(callback)` to set the version string that `renderDefaultVersion()` returns. Without a string override, it defaults to the nearest `package.json` version.
+
+## Disabling --help or --version
+
+Pass `false` to suppress help or version output:
+
+```typescript
+cli('my-tool')
+  .help(false)    // --help won't print help text
+  .version(false) // --version won't print version
+```
+
+When disabled, the flag won't appear in help text and passing it won't trigger any special behavior — the handler runs normally as if `--help` wasn't passed.
+
+Disabling works at any command level. You can disable help on a specific subcommand while keeping it active on the root:
+
+```typescript
+cli('my-tool')
+  .command('internal', {
+    builder: (args) =>
+      args
+        .help(false) // no help for this subcommand
+        .option('key', { type: 'string' }),
+    handler: (args) => { /* ... */ },
+  });
+```
+
+Calling `.help(callback)` or `.version(string | callback)` after disabling re-enables the feature.
+
+## Help callback inheritance
+
+Help callbacks propagate down the command tree. If a subcommand doesn't define its own `.help()` callback, it inherits from its closest ancestor that has one:
+
+```typescript
+cli('my-tool')
+  .help(({ renderDefaultHelp }) => {
+    return `my-tool v1.0.0\n\n${renderDefaultHelp()}`;
+  })
+  .command('build', {
+    builder: (args) => args.option('watch', { type: 'boolean' }),
+    handler: (args) => { /* ... */ },
+  })
+  .command('serve', {
+    builder: (args) =>
+      args
+        // Override the inherited help callback for this subcommand only
+        .help(({ renderDefaultHelp }) => {
+          return `Server Help\n\n${renderDefaultHelp()}`;
+        })
+        .option('port', { type: 'number', default: 3000 }),
+    handler: (args) => { /* ... */ },
+  });
+```
+
+Running `my-tool build --help` uses the root help callback. Running `my-tool serve --help` uses the serve-specific one.
+
+## Working with options in help callbacks
+
+The `options` array in the help context gives you each visible (non-hidden, non-positional) option as an `OptionInfo` object:
+
+| Property | Description |
+|---|---|
+| `key` | The option's storage key (e.g. `"port"`). |
+| `config` | The full option configuration object. |
+| `renderHelpText()` | Renders the help line for this option, respecting any `formatHelpText` override. |
+
+This is useful for building fully custom help layouts:
+
+```typescript
+cli('my-tool')
+  .option('port', { type: 'number', description: 'Port to listen on' })
+  .option('host', { type: 'string', description: 'Hostname' })
+  .help(({ options }) => {
+    const lines = ['my-tool options:', ''];
+    for (const opt of options) {
+      // renderHelpText() applies any per-option formatHelpText override
+      lines.push(opt.renderHelpText());
+    }
+    return lines.join('\n');
+  });
+```
+
+## Per-option help text
+
+Add a `formatHelpText` callback to any option to customize how that specific option renders in help output:
+
+<%= example('help-customization').region('options') %>
+
+The callback receives the option's configuration object and the default text string. Return the replacement line for that option in the help output. Options without `formatHelpText` render normally.
+
+When a help callback calls `option.renderHelpText()`, per-option `formatHelpText` overrides are automatically applied.
+
+## Error handling with .catch()
+
+By default, CLI Forge prints help text and error details when validation fails (e.g., a required option is missing). Use `.catch()` to replace this behavior, similar to how `Promise.catch()` works:
+
+<%= example('help-customization').region('catch') %>
+
+The catch handler receives:
+
+| Parameter | Description |
+|---|---|
+| `error` | The error that was thrown. |
+| `context.cli` | The CLI instance. |
+| `context.exit(code?)` | Exit the process. Prefer this over `process.exit` for interactive shell support. |
+| `context.renderDefaultHelp()` | Renders the default help text, useful for including in custom error output. |
+
+When a `.catch()` handler is registered, it replaces the default validation error handler entirely. It follows `Promise.catch()` semantics: if the handler returns normally, the error is suppressed and `forge()` returns. If the handler rethrows (or throws a new error), the error propagates to callers of `forge()`.

--- a/examples/help-customization.ts
+++ b/examples/help-customization.ts
@@ -1,0 +1,147 @@
+// ---
+// id: help-customization
+// title: Help & Version Customization
+// description: |
+//   Demonstrates how to customize the `--help` and `--version` output for a CLI.
+//
+//   You can:
+//   - Pass a callback to `.help()` to customize the full help text
+//   - Pass a callback to `.version()` to customize the version output
+//   - Disable either flag entirely with `.help(false)` or `.version(false)`
+//   - Use `formatHelpText` on individual options for per-option customization
+//   - Use `.catch()` to customize error handling (e.g. suppress or restyle the
+//     default validation-error + help output)
+//
+//   Help callbacks receive a context object with:
+//   - `args` — the parsed arguments at the time `--help` was invoked (partial)
+//   - `cli` — the CLI instance
+//   - `renderDefaultHelp()` — renders the full default help text
+//   - `options` — configured options, each with a `renderHelpText()` method
+//
+//   Custom help callbacks are inherited by subcommands. If a subcommand does not
+//   define its own, it walks up the parent chain.
+// test:
+//   - name: "Custom help text"
+//     options:
+//       command: 'npx tsx --no-cache --tsconfig ./tsconfig.json help-customization.ts --help'
+//     assertions:
+//       stdout:
+//         contains: 'my-tool v1.0.0'
+//         matches: 'Usage: my-tool'
+//   - name: "Verbose help text"
+//     options:
+//       command: 'npx tsx --no-cache --tsconfig ./tsconfig.json help-customization.ts --verbose --help'
+//     assertions:
+//       stdout:
+//         contains: 'VERBOSE HELP'
+//   - name: "Custom version text"
+//     options:
+//       command: 'npx tsx --no-cache --tsconfig ./tsconfig.json help-customization.ts --version'
+//     assertions:
+//       stdout:
+//         contains: 'my-tool v1.0.0 (custom build)'
+//   - name: "Subcommand inherits help"
+//     options:
+//       command: 'npx tsx --no-cache --tsconfig ./tsconfig.json help-customization.ts serve --help'
+//     assertions:
+//       stdout:
+//         contains: 'my-tool v1.0.0'
+//         matches: 'Usage: my-tool serve'
+//   - name: "Per-option help text"
+//     options:
+//       command: 'npx tsx --no-cache --tsconfig ./tsconfig.json help-customization.ts --help'
+//     assertions:
+//       stdout:
+//         contains: '[output directory path]'
+// ---
+import cliForge from 'cli-forge';
+
+// #region cli
+const cli = cliForge('my-tool')
+  .option('verbose', {
+    type: 'boolean',
+    alias: ['v'],
+    description: 'Enable verbose output',
+  })
+  // #region help
+  // Custom help callback — receives a context object you can destructure.
+  // The callback is inherited by subcommands that don't define their own.
+  .help(({ args, renderDefaultHelp, options }) => {
+    // Add a branded header with the tool version
+    let output = `my-tool v1.0.0\n\n${renderDefaultHelp()}`;
+
+    // `args` is partial (parse may not have finished), so check safely
+    if (args.verbose) {
+      output += '\n\nVERBOSE HELP: extra debugging information shown here';
+    }
+
+    // `options` gives you each configured option with a renderHelpText()
+    // method that respects per-option formatHelpText overrides — useful
+    // for building fully custom help layouts.
+    const userOptions = options.filter(
+      (o) => o.key !== 'help' && o.key !== 'version'
+    );
+    output += `\n\n${userOptions.length} user-defined option(s)`;
+
+    return output;
+  })
+  // #endregion help
+  // #region version
+  // Customize version output. Set the version string first, then
+  // provide a callback that wraps the default output.
+  .version('1.0.0')
+  .version(({ renderDefaultVersion }) => {
+    return `my-tool v${renderDefaultVersion()} (custom build)`;
+  })
+  // #endregion version
+  // #region options
+  .option('output', {
+    type: 'string',
+    description: 'Output directory',
+    default: './dist',
+    // Per-option help customization: the callback receives the option
+    // config and the default text, and returns the replacement line.
+    formatHelpText: (_option, _defaultText) => {
+      return '  --output - Output directory [output directory path] [default: ./dist]';
+    },
+  })
+  // #endregion options
+  // #region catch
+  // .catch() replaces the default validation-error handler, which
+  // normally prints help + error messages and exits. This lets you
+  // control what users see on bad input.
+  .catch((error, { renderDefaultHelp, exit }) => {
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+    }
+    console.error(`\nRun "my-tool --help" for usage information.`);
+    exit(1);
+  })
+  // #endregion catch
+  .command('serve', {
+    description: 'Start a development server',
+    builder: (args) =>
+      args.option('port', {
+        type: 'number',
+        description: 'Port to listen on',
+        default: 3000,
+      }),
+    handler: (args) => {
+      console.log(`Serving on port ${args.port}`);
+    },
+  })
+  .command('build', {
+    description: 'Build the project',
+    handler: (args) => {
+      console.log(`Building to ${args.output}`);
+    },
+  });
+// #endregion cli
+
+export default cli;
+
+if (require.main === module) {
+  (async () => {
+    await cli.forge();
+  })();
+}

--- a/packages/cli-forge/src/lib/format-help.ts
+++ b/packages/cli-forge/src/lib/format-help.ts
@@ -7,7 +7,10 @@ import {
 } from '@cli-forge/parser';
 import { AnyInternalCLI } from './internal-cli';
 
-export function formatHelp(parentCLI: AnyInternalCLI): string {
+export function formatHelp(
+  parentCLI: AnyInternalCLI,
+  hiddenKeys?: Set<string>
+): string {
   const help: string[] = [];
   let command = parentCLI;
   let epilogue = parentCLI.configuration?.epilogue;
@@ -69,7 +72,9 @@ export function formatHelp(parentCLI: AnyInternalCLI): string {
   const groupedOptions = parentCLI.getGroupedOptions();
   const nonpositionalOptions = Object.values(
     command.parser.configuredOptions
-  ).filter((c) => !c.positional && !c.hidden);
+  ).filter(
+    (c) => !c.positional && !c.hidden && !(hiddenKeys && hiddenKeys.has(c.key))
+  );
 
   help.push(...getOptionBlock('Options', nonpositionalOptions, command.parser));
 
@@ -110,6 +115,30 @@ export function formatHelp(parentCLI: AnyInternalCLI): string {
   }
 
   return help.join('\n');
+}
+
+/**
+ * Renders a single option's help text line, applying any per-option
+ * `formatHelpText` override.
+ *
+ * Note: The returned text is **not** column-aligned, since alignment
+ * requires knowing all sibling options. This matches the `defaultText`
+ * passed to `formatHelpText` callbacks in the full help output.
+ *
+ * @param option The option configuration.
+ * @param displayKey The display key (may be localized).
+ * @returns The formatted help text line for this option.
+ */
+export function renderOptionHelpText(
+  option: UnknownOptionConfig & { key: string },
+  displayKey: string
+): string {
+  const parts = getOptionParts(option);
+  const defaultText = `  --${displayKey}${parts.length ? ' - ' : ''}${parts.join(' ')}`;
+  if (option.formatHelpText) {
+    return option.formatHelpText(option as any, defaultText);
+  }
+  return defaultText;
 }
 
 function getOptionParts(option: UnknownOptionConfig) {
@@ -270,11 +299,14 @@ function getOptionBlock(
     lines.push(label + ':');
   }
 
-  // Collect all entries (options + their property sub-entries) into a flat list
+  // Collect all entries (options + their property sub-entries) into a flat list.
+  // Options with a custom `formatHelpText` get a `customRender` function that
+  // replaces the standard aligned rendering for that entry.
   const entries: Array<{
     flagColumn: string;
     parts: string[];
     indent: number;
+    customRender?: (defaultText: string) => string;
   }> = [];
 
   for (const option of options) {
@@ -284,6 +316,9 @@ function getOptionBlock(
       flagColumn: buildFlagColumn(displayKey, aliases),
       parts: getOptionParts(option),
       indent: 0,
+      customRender: option.formatHelpText
+        ? (_defaultText) => option.formatHelpText!(option as any, _defaultText)
+        : undefined,
     });
     for (const { key, config } of getPropertyEntries(option)) {
       entries.push({
@@ -294,18 +329,22 @@ function getOptionBlock(
     }
   }
 
-  // Compute flag column width accounting for indent so all `-` separators align
+  // Compute flag column width accounting for indent so all `-` separators align.
+  // Custom-rendered entries are excluded from padding calculation.
   let flagColumnWidth = 0;
   for (const entry of entries) {
-    flagColumnWidth = Math.max(
-      flagColumnWidth,
-      entry.indent + entry.flagColumn.length
-    );
+    if (!entry.customRender) {
+      flagColumnWidth = Math.max(
+        flagColumnWidth,
+        entry.indent + entry.flagColumn.length
+      );
+    }
   }
 
-  // Compute padding for each part column across all entries
+  // Compute padding for each part column across standard entries
   const partPadding: number[] = [];
   for (const entry of entries) {
+    if (entry.customRender) continue;
     for (let j = 0; j < entry.parts.length; j++) {
       if (!partPadding[j]) {
         partPadding[j] = 0;
@@ -314,13 +353,22 @@ function getOptionBlock(
     }
   }
 
-  for (const { flagColumn, parts, indent } of entries) {
-    const paddedFlagColumn = flagColumn.padEnd(flagColumnWidth - indent);
-    lines.push(
-      `${' '.repeat(2 + indent)}${paddedFlagColumn}${
-        parts.length ? ' - ' : ''
-      }${parts.map((part, i) => part.padEnd(partPadding[i])).join(' ')}`
-    );
+  // Render in original order — custom entries use their callback,
+  // standard entries use column-aligned formatting.
+  for (const { flagColumn, parts, indent, customRender } of entries) {
+    const defaultText = `${' '.repeat(2 + indent)}${flagColumn}${
+      parts.length ? ' - ' : ''
+    }${parts.join(' ')}`;
+    if (customRender) {
+      lines.push(customRender(defaultText));
+    } else {
+      const paddedFlagColumn = flagColumn.padEnd(flagColumnWidth - indent);
+      lines.push(
+        `${' '.repeat(2 + indent)}${paddedFlagColumn}${
+          parts.length ? ' - ' : ''
+        }${parts.map((part, i) => part.padEnd(partPadding[i])).join(' ')}`
+      );
+    }
   }
   return lines;
 }

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -1958,4 +1958,270 @@ describe('cliForge', () => {
       expect(handlerArgs.verbose).toBe(false); // default, not prompted
     });
   });
+
+  describe('help customization', () => {
+    it('should support disabling --help', async () => {
+      const { getOutput } = mockConsoleLog();
+      let handlerRan = false;
+      await cli('test')
+        .help(false)
+        .command('$0', {
+          handler: () => {
+            handlerRan = true;
+          },
+        })
+        .forge(['--help']);
+      // When --help is disabled, the handler should run and --help should not produce help text
+      expect(handlerRan).toBe(true);
+      expect(getOutput()).toBe('');
+    });
+
+    it('should support custom help callback with object context', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('foo', { type: 'string' })
+        .help(({ renderDefaultHelp }) => {
+          return `CUSTOM HELP\n${renderDefaultHelp()}`;
+        })
+        .forge(['--help']);
+      const output = getOutput();
+      expect(output).toContain('CUSTOM HELP');
+      expect(output).toContain('Usage: test');
+    });
+
+    it('should pass parsed args to help callback', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('verbose', { type: 'boolean', alias: ['v'] })
+        .help(({ args, renderDefaultHelp }) => {
+          if (args.verbose) {
+            return `VERBOSE MODE\n${renderDefaultHelp()}`;
+          }
+          return renderDefaultHelp();
+        })
+        .forge(['--verbose', '--help']);
+      const output = getOutput();
+      expect(output).toContain('VERBOSE MODE');
+    });
+
+    it('should inherit help callback from parent command', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .help(({ renderDefaultHelp }) => {
+          return `INHERITED HELP\n${renderDefaultHelp()}`;
+        })
+        .command('sub', {
+          builder: (argv) => argv.option('bar', { type: 'string' }),
+          handler: () => {
+            // No side effect needed.
+          },
+        })
+        .forge(['sub', '--help']);
+      const output = getOutput();
+      expect(output).toContain('INHERITED HELP');
+    });
+
+    it('should allow subcommand to override parent help callback', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .help(() => 'PARENT HELP')
+        .command('sub', {
+          builder: (argv) =>
+            argv
+              .help(() => 'CHILD HELP')
+              .option('bar', { type: 'string' }),
+          handler: () => {
+            // No side effect needed.
+          },
+        })
+        .forge(['sub', '--help']);
+      expect(getOutput()).toBe('CHILD HELP');
+    });
+
+    it('should hide --help from help text when disabled', async () => {
+      const app = cli('test')
+        .help(false)
+        .option('foo', { type: 'string' });
+      const helpText = (app as any).formatHelp();
+      expect(helpText).not.toContain('--help');
+      expect(helpText).toContain('--version');
+      expect(helpText).toContain('--foo');
+    });
+
+    it('should re-enable --help after .help(false) when callback is provided', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .help(false)
+        .help(({ renderDefaultHelp }) => `RE-ENABLED\n${renderDefaultHelp()}`)
+        .forge(['--help']);
+      expect(getOutput()).toContain('RE-ENABLED');
+      expect(getOutput()).toContain('--help');
+    });
+
+    it('should disable help on a subcommand while keeping it on root', async () => {
+      const { getOutput } = mockConsoleLog();
+      let handlerRan = false;
+      await cli('test')
+        .command('secret', {
+          builder: (argv) =>
+            argv
+              .help(false)
+              .option('key', { type: 'string' }),
+          handler: () => {
+            handlerRan = true;
+          },
+        })
+        .forge(['secret', '--help']);
+      // Help is disabled on the subcommand, so handler runs instead
+      expect(handlerRan).toBe(true);
+      expect(getOutput()).toBe('');
+    });
+  });
+
+  describe('version customization', () => {
+    it('should support disabling --version', async () => {
+      const { getOutput } = mockConsoleLog();
+      let handlerRan = false;
+      await cli('test')
+        .version(false)
+        .command('$0', {
+          handler: () => {
+            handlerRan = true;
+          },
+        })
+        .forge(['--version']);
+      expect(handlerRan).toBe(true);
+      expect(getOutput()).toBe('');
+    });
+
+    it('should support custom version callback with object context', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .version(({ renderDefaultVersion }) => {
+          return `custom-app v${renderDefaultVersion()}`;
+        })
+        .forge(['--version']);
+      const output = getOutput();
+      expect(output).toContain('custom-app v');
+    });
+
+    it('should still support version string override', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test').version('1.2.3').forge(['--version']);
+      expect(getOutput()).toBe('1.2.3');
+    });
+  });
+
+  describe('per-option formatHelpText', () => {
+    it('should use custom formatHelpText for an option', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('foo', {
+          type: 'string',
+          description: 'A foo option',
+          formatHelpText: (_option, defaultText) => {
+            return `${defaultText} [CUSTOM]`;
+          },
+        })
+        .forge(['--help']);
+      const output = getOutput();
+      expect(output).toContain('[CUSTOM]');
+      expect(output).toContain('A foo option');
+    });
+  });
+
+  describe('help context options', () => {
+    it('should provide options with renderHelpText in help callback', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('port', { type: 'number', description: 'Port number' })
+        .option('host', { type: 'string', description: 'Hostname' })
+        .help(({ options, renderDefaultHelp }) => {
+          const optLines = options
+            .filter((o) => o.key !== 'help' && o.key !== 'version')
+            .map((o) => o.renderHelpText());
+          return `Custom:\n${optLines.join('\n')}\n---\n${renderDefaultHelp()}`;
+        })
+        .forge(['--help']);
+      const output = getOutput();
+      expect(output).toContain('Custom:');
+      expect(output).toContain('Port number');
+      expect(output).toContain('Hostname');
+      expect(output).toContain('---');
+    });
+
+    it('should respect per-option formatHelpText in renderHelpText', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('port', {
+          type: 'number',
+          description: 'Port',
+          formatHelpText: (_opt, defaultText) => `${defaultText} [CUSTOM PORT]`,
+        })
+        .help(({ options }) => {
+          return options.map((o) => o.renderHelpText()).join('\n');
+        })
+        .forge(['--help']);
+      const output = getOutput();
+      expect(output).toContain('[CUSTOM PORT]');
+    });
+  });
+
+  describe('.catch() error handler', () => {
+    it('should suppress error when handler returns normally', async () => {
+      const { getOutput } = mockConsoleLog();
+      let caughtError: unknown;
+      // No try/catch — forge() should NOT throw since the handler suppresses.
+      await cli('test')
+        .option('name', { type: 'string', required: true })
+        .catch((error) => {
+          caughtError = error;
+          console.log('CAUGHT');
+        })
+        .command('$0', {
+          handler: () => {
+            // should not run
+          },
+        })
+        .forge([]);
+      expect(caughtError).toBeDefined();
+      expect(getOutput()).toBe('CAUGHT');
+    });
+
+    it('should propagate error when handler rethrows', async () => {
+      let threw = false;
+      try {
+        await cli('test')
+          .option('name', { type: 'string', required: true })
+          .catch((error) => {
+            throw error;
+          })
+          .command('$0', {
+            handler: () => {
+              // should not run
+            },
+          })
+          .forge([]);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    });
+
+    it('should provide renderDefaultHelp in catch context', async () => {
+      const { getOutput } = mockConsoleLog();
+      await cli('test')
+        .option('name', { type: 'string', required: true })
+        .catch((_error, { renderDefaultHelp }) => {
+          console.log(`Error! ${renderDefaultHelp().split('\n')[0]}`);
+        })
+        .command('$0', {
+          handler: () => {
+            // should not run
+          },
+        })
+        .forge([]);
+      expect(getOutput()).toContain('Error! Usage: test');
+    });
+  });
 });

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -18,7 +18,7 @@ import { readOptionGroupsForCLI } from './cli-option-groups';
 import { contextStorage, ForgeContextData } from './async-context';
 import { getCommandContext } from './context';
 import type { CommandContext, ProvidersFromChain } from './context';
-import { formatHelp } from './format-help';
+import { formatHelp, renderOptionHelpText } from './format-help';
 // Lazy-imported to avoid pulling Node-only modules (readline, child_process)
 // into the module graph when bundled for the browser.
 type InteractiveShellModule = typeof import('./interactive-shell.js');
@@ -31,12 +31,18 @@ async function getInteractiveShellModule(): Promise<InteractiveShellModule> {
 }
 import {
   AnyCLI,
+  CatchHandler,
   CLI,
   CLICommandOptions,
   CLIHandlerContext,
   Command,
   ErrorHandler,
+  HelpCallback,
+  HelpContext,
+  OptionInfo,
   SDKCommand,
+  VersionCallback,
+  VersionContext,
 } from './public-api';
 import type {
   CompletionCallback,
@@ -159,6 +165,16 @@ export class InternalCLI<
   private _configuration?: CLICommandOptions<any, any>;
 
   private _versionOverride?: string;
+
+  private _versionDisabled = false;
+
+  private _versionCallback?: VersionCallback<TArgs>;
+
+  private _helpDisabled = false;
+
+  private _helpCallback?: HelpCallback<TArgs>;
+
+  private _catchHandler?: CatchHandler<TArgs>;
 
   private registeredErrorHandlers: Array<ErrorHandler> = [
     (e: unknown, actions) => {
@@ -334,6 +350,19 @@ export class InternalCLI<
     this.configuration = configuration;
     this.requiresCommand = configuration.handler ? false : 'IMPLICIT';
     return this;
+  }
+
+  /**
+   * Resolves the target command at the end of the command chain.
+   * Returns `this` if the command chain is empty.
+   */
+  private resolveTargetCommand(): InternalCLI<any, any, any, any> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let cmd: InternalCLI<any, any, any, any> = this;
+    for (const key of this.commandChain) {
+      cmd = cmd.registeredCommands[key];
+    }
+    return cmd;
   }
 
   command<
@@ -589,24 +618,118 @@ export class InternalCLI<
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   }
 
-  version(version?: string): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
-    this._versionOverride = version;
+  version(
+    overrideOrCallbackOrEnabled?: string | false | VersionCallback<TArgs>
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
+    if (overrideOrCallbackOrEnabled === false) {
+      this._versionDisabled = true;
+      this._versionCallback = undefined;
+      this._versionOverride = undefined;
+    } else if (typeof overrideOrCallbackOrEnabled === 'function') {
+      this._versionDisabled = false;
+      this._versionCallback = overrideOrCallbackOrEnabled;
+    } else {
+      this._versionDisabled = false;
+      this._versionOverride = overrideOrCallbackOrEnabled;
+    }
+    return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  }
+
+  help(
+    callbackOrEnabled?: false | HelpCallback<TArgs>
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
+    if (callbackOrEnabled === false) {
+      this._helpDisabled = true;
+      this._helpCallback = undefined;
+    } else if (typeof callbackOrEnabled === 'function') {
+      this._helpDisabled = false;
+      this._helpCallback = callbackOrEnabled;
+    }
+    return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  }
+
+  catch(
+    handler: CatchHandler<TArgs>
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
+    this._catchHandler = handler;
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   }
 
   /**
+   * Builds the array of {@link OptionInfo} for visible options, each with
+   * a `renderHelpText()` that respects per-option `formatHelpText` overrides.
+   */
+  private buildOptionInfos(): OptionInfo[] {
+    const hiddenKeys = this.getDisabledBuiltinKeys();
+    const opts = Object.values(this.parser.configuredOptions).filter(
+      (c) =>
+        !c.positional && !c.hidden && !(hiddenKeys && hiddenKeys.has(c.key))
+    );
+    return opts.map((opt) => ({
+      key: opt.key,
+      config: opt,
+      renderHelpText: () =>
+        renderOptionHelpText(opt, this.parser.getDisplayKey(opt.key)),
+    }));
+  }
+
+  /**
    * Gets help text for the current command as a string.
+   * If a custom help callback is set on this command or an ancestor, it is used.
+   * @param args Optional parsed args to pass to a custom help callback.
    * @returns Help text for the current command.
    */
-  formatHelp() {
-    return formatHelp(this);
+  formatHelp(args?: Partial<TArgs>) {
+    const hiddenKeys = this.getDisabledBuiltinKeys();
+    const helpCallback = this.resolveHelpCallback();
+    if (helpCallback) {
+      const resolvedCmd = this.resolveTargetCommand();
+      const context: HelpContext<TArgs> = {
+        cli: resolvedCmd as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>,
+        args: args ?? ({} as Partial<TArgs>),
+        renderDefaultHelp: () =>
+          formatHelp(this as AnyInternalCLI, hiddenKeys),
+        options: this.buildOptionInfos(),
+      };
+      return helpCallback(context);
+    }
+    return formatHelp(this, hiddenKeys);
+  }
+
+  /**
+   * Returns built-in option keys disabled on the resolved command,
+   * so they can be filtered from help output.
+   */
+  private getDisabledBuiltinKeys(): Set<string> | undefined {
+    const cmd = this.resolveTargetCommand();
+    const keys = new Set<string>();
+    if (cmd._helpDisabled) keys.add('help');
+    if (cmd._versionDisabled) keys.add('version');
+    return keys.size > 0 ? keys : undefined;
+  }
+
+  /**
+   * Walks the resolved command chain and then parent chain to find a custom
+   * help callback. Returns undefined if none is found.
+   */
+  private resolveHelpCallback(): HelpCallback<TArgs> | undefined {
+    const cmd = this.resolveTargetCommand();
+    let current: InternalCLI<any, any, any, any> | undefined = cmd;
+    while (current) {
+      if (current._helpCallback) {
+        return current._helpCallback;
+      }
+      current = current._parent;
+    }
+    return undefined;
   }
 
   /**
    * Prints help text for the current command to the console.
+   * @param args Optional parsed args to pass to a custom help callback.
    */
-  printHelp() {
-    console.log(this.formatHelp());
+  printHelp(args?: Partial<TArgs>) {
+    console.log(this.formatHelp(args));
   }
 
   middleware<TArgs2>(
@@ -704,9 +827,10 @@ export class InternalCLI<
    * @param args The arguments to pass to the command.
    */
   async runCommand<T extends ParsedArgs>(
-    args: T,
+    args: T & { help?: boolean; version?: boolean },
     originalArgV: string[],
-    executedMiddleware?: Set<(args: any) => void>
+    executedMiddleware?: Set<(args: any) => void>,
+    validationFailedError?: ValidationFailedError<any>
   ): Promise<T> {
     const middlewares = new Set<(args: any) => void>(this.registeredMiddleware);
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -717,6 +841,28 @@ export class InternalCLI<
         middlewares.add(mw);
       }
     }
+
+    // Pre-handler: --version and --help.
+    // These run with the resolved command so per-command disabling and
+    // custom callbacks are naturally in scope.  They take priority over
+    // validation errors so that `my-app --required-opt --help` still works.
+    // We call version/help on `this` (root) so the full command chain is
+    // available for rendering, but check the resolved `cmd`'s disabled state.
+    if (args.version && !cmd._versionDisabled) {
+      this.versionHandler(args as any);
+      return args;
+    }
+    if (args.help && !cmd._helpDisabled) {
+      this.printHelp(args as any);
+      return args;
+    }
+
+    // If help/version didn't fire but we captured a validation error
+    // during the final parse, throw it now.
+    if (validationFailedError) {
+      throw validationFailedError;
+    }
+
     try {
       if (cmd.requiresCommand) {
         throw new Error(
@@ -1037,29 +1183,55 @@ export class InternalCLI<
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   }
 
-  private versionHandler() {
+  private defaultVersionString(): string {
     if (this._versionOverride) {
-      console.log(this._versionOverride);
-      return;
+      return this._versionOverride;
     }
     let mainFile = typeof require !== 'undefined' ? require?.main?.filename : undefined;
     mainFile ??= getCallingFile();
     if (!mainFile) {
-      console.log('unknown');
-      return;
+      return 'unknown';
     }
     try {
       const packageJson = getParentPackageJson(mainFile);
-      console.log(packageJson.version ?? 'unknown');
+      return packageJson.version ?? 'unknown';
     } catch {
-      console.log('unknown');
+      return 'unknown';
     }
+  }
+
+  private versionHandler(args?: Partial<TArgs>) {
+    if (this._versionCallback) {
+      const context: VersionContext<TArgs> = {
+        cli: this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>,
+        args: args ?? ({} as Partial<TArgs>),
+        renderDefaultVersion: () => this.defaultVersionString(),
+      };
+      console.log(this._versionCallback(context));
+      return;
+    }
+    console.log(this.defaultVersionString());
   }
 
   private async withErrorHandlers<T>(cb: () => T): Promise<Awaited<T>> {
     try {
       return await cb();
     } catch (e) {
+      // If a .catch() handler is registered, use it instead of the default
+      // error handler chain. Follows Promise.catch semantics: if the handler
+      // returns normally the error is suppressed; if it rethrows, it propagates.
+      if (this._catchHandler) {
+        this._catchHandler(e, {
+          cli: this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>,
+          exit: (c) => {
+            if (typeof process !== 'undefined') process.exit(c);
+          },
+          renderDefaultHelp: () => formatHelp(this as AnyInternalCLI),
+        });
+        // Handler returned normally — suppress the error.
+        return undefined as Awaited<T>;
+      }
+
       for (const handler of this.registeredErrorHandlers) {
         try {
           handler(e, {
@@ -1392,18 +1564,6 @@ export class InternalCLI<
         }
       }
 
-      if (argv.version) {
-        this.versionHandler();
-        return argv;
-      }
-
-      if (argv.help) {
-        this.printHelp();
-        return argv;
-      } else if (validationFailedError) {
-        throw validationFailedError;
-      }
-
       // Collect all providers from the command chain (root → subcommands)
       const allProviders = this.collectProviders();
       const contextData: ForgeContextData = {
@@ -1430,7 +1590,12 @@ export class InternalCLI<
 
       const finalArgV = await contextStorage.run(contextData, async () => {
         contextData.handlerPhase = true;
-        return this.runCommand(argv, args, executedMiddleware);
+        return this.runCommand(
+          argv,
+          args,
+          executedMiddleware,
+          validationFailedError
+        );
       });
       return finalArgV as TArgs;
     });
@@ -1507,6 +1672,12 @@ export class InternalCLI<
     clone.completionCallback = this.completionCallback;
     clone.completionConfigs = new Map(this.completionConfigs);
     clone._completionEnabled = this._completionEnabled;
+    clone._helpDisabled = this._helpDisabled;
+    clone._helpCallback = this._helpCallback;
+    clone._versionDisabled = this._versionDisabled;
+    clone._versionCallback = this._versionCallback;
+    clone._versionOverride = this._versionOverride;
+    clone._catchHandler = this._catchHandler;
     return clone;
   }
 }

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -16,6 +16,7 @@ import {
   ParsedArgs,
   ResolveProperties,
   StringOptionConfig,
+  UnknownOptionConfig,
   WithOptional,
 } from '@cli-forge/parser';
 
@@ -77,6 +78,100 @@ export type ExtractCommandProviders<T> = T extends CLI<any, any, any, any, infer
   : T extends CLICommandOptions<any, any, any, any, any, any, infer P>
   ? P
   : {};
+
+/**
+ * Public-facing representation of a configured option with a method to render
+ * its help text line (respecting any per-option `formatHelpText` override).
+ */
+export interface OptionInfo {
+  /** The option key (storage name). */
+  key: string;
+  /** The option's full configuration. */
+  config: UnknownOptionConfig;
+  /**
+   * Renders the help text line for this option, applying any per-option
+   * `formatHelpText` override. Returns the default formatted line if no
+   * override is set.
+   */
+  renderHelpText: () => string;
+}
+
+/**
+ * Context object passed to help callbacks.
+ *
+ * @typeParam TArgs - The accumulated argument types. Typed as `Partial`
+ *   because help may be invoked before a successful parse.
+ */
+export interface HelpContext<TArgs extends ParsedArgs = ParsedArgs> {
+  /** The CLI instance for the command being helped. */
+  cli: CLI<TArgs, any, any, any>;
+  /** The parsed arguments at the time --help was invoked (partial — parse may not have succeeded). */
+  args: Partial<TArgs>;
+  /**
+   * Renders the full default help text that would be shown without customization.
+   * Call this to get the standard help output and augment it.
+   */
+  renderDefaultHelp: () => string;
+  /**
+   * All visible (non-hidden, non-positional) options with their configs and
+   * a `renderHelpText()` method that respects per-option overrides.
+   */
+  options: OptionInfo[];
+}
+
+/**
+ * Callback for customizing help text generation.
+ */
+export type HelpCallback<TArgs extends ParsedArgs = ParsedArgs> = (
+  context: HelpContext<TArgs>
+) => string;
+
+/**
+ * Context object passed to version callbacks.
+ */
+export interface VersionContext<TArgs extends ParsedArgs = ParsedArgs> {
+  /** The CLI instance. */
+  cli: CLI<TArgs, any, any, any>;
+  /** The parsed arguments at the time --version was invoked (partial — parse may not have succeeded). */
+  args: Partial<TArgs>;
+  /**
+   * Renders the default version string that would be shown without customization.
+   */
+  renderDefaultVersion: () => string;
+}
+
+/**
+ * Callback for customizing version output.
+ */
+export type VersionCallback<TArgs extends ParsedArgs = ParsedArgs> = (
+  context: VersionContext<TArgs>
+) => string;
+
+/**
+ * Callback for handling errors during CLI execution, similar to `Promise.catch()`.
+ *
+ * - If the handler returns normally, the error is **suppressed** and `forge()` returns.
+ * - If the handler rethrows (or throws a new error), the error **propagates** to the caller.
+ *
+ * When registered, this replaces the default validation-error handler entirely.
+ */
+export type CatchHandler<TArgs extends ParsedArgs = ParsedArgs> = (
+  error: unknown,
+  context: {
+    /** The CLI instance. */
+    cli: CLI<TArgs, any, any, any>;
+    /**
+     * Exit the process with the given code. Prefer using this helper over
+     * calling `process.exit` directly so the CLI can manage process
+     * termination consistently across environments.
+     */
+    exit: (code?: number) => void;
+    /**
+     * Render the default help text. Useful for printing help alongside error messages.
+     */
+    renderDefaultHelp: () => string;
+  }
+) => void;
 
 /**
  * Converts a Command to its child CLI entry for TChildren tracking.
@@ -861,14 +956,48 @@ export interface CLI<
   /**
    * Allows overriding the version displayed when passing `--version`. Defaults to crawling
    * the file system to get the package.json of the currently executing command.
-   * @param override
+   *
+   * Can also be used to disable the `--version` flag by passing `false`
+   * (works at any command level), or to provide a custom version handler
+   * callback. Calling `.version(string|callback)` after `.version(false)`
+   * re-enables it.
    */
-  version(override?: string): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  version(override: string): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  version(enabled: false): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  version(callback: VersionCallback<TArgs>): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  version(overrideOrCallbackOrEnabled?: string | false | VersionCallback<TArgs>): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+
+  /**
+   * Configures the `--help` flag behavior.
+   *
+   * - Pass `false` to disable `--help` for this command. The flag is still
+   *   parsed but won't trigger help output and won't appear in help text.
+   *   Works at any command level (root or subcommand).
+   *   Calling `.help(callback)` after `.help(false)` re-enables it.
+   * - Pass a callback to customize help text generation for this command.
+   *   The callback receives a {@link HelpContext} with the CLI instance, parsed args,
+   *   configured options (each with a `renderHelpText()` method), and a
+   *   `renderDefaultHelp()` function for the full default help text.
+   *   If a subcommand does not have its own help callback, it will inherit from its closest
+   *   ancestor that has one.
+   */
+  help(enabled: false): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  help(callback: HelpCallback<TArgs>): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  help(callbackOrEnabled?: false | HelpCallback<TArgs>): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   /**
    * Prints help text to stdout.
+   * @param args Optional parsed args to pass to a custom help callback.
    */
-  printHelp(): void;
+  printHelp(args?: Partial<TArgs>): void;
+
+  /**
+   * Registers an error handler that replaces the default validation-error behavior
+   * (which prints help + error messages and exits). Works like `Promise.catch()`:
+   * if the handler returns normally, the error is suppressed and `forge()` returns.
+   * If the handler rethrows (or throws a new error), the error propagates.
+   */
+  catch(handler: CatchHandler<TArgs>): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   group({
     label,

--- a/packages/parser/src/lib/option-types/common.ts
+++ b/packages/parser/src/lib/option-types/common.ts
@@ -125,4 +125,14 @@ export type CommonOptionConfig<T, TCoerce = T, TChoices = T[]> = {
    * Can be set to group options in help output and generated docs.
    */
   group?: string;
+
+  /**
+   * Custom function to format this option's help text. When set, the return value
+   * replaces the default help line for this option.
+   *
+   * @param option The option's configuration.
+   * @param defaultText The default help text that would be generated for this option.
+   * @returns The custom help text to display for this option.
+   */
+  formatHelpText?: (option: CommonOptionConfig<T, TCoerce, TChoices>, defaultText: string) => string;
 };


### PR DESCRIPTION
## Summary

- Add `.help(false)` and `.version(false)` to disable the built-in flags entirely
- Add `.help(callback)` and `.version(callback)` for custom help/version output with access to the default text via a provided function
- Help callbacks inherit from parent commands — subcommands without a custom callback walk up the parent chain
- Add per-option `formatHelpText` callback on option configs to customize individual option help lines

Closes #46

## Test plan

- [x] `.help(false)` disables `--help` flag (handler runs instead of printing help)
- [x] `.help(callback)` uses custom formatter with access to default help text
- [x] Help callback inherited by child commands from parent
- [x] Subcommand can override parent's help callback
- [x] `.help(false)` hides `--help` from help text output
- [x] `.version(false)` disables `--version` flag
- [x] `.version(callback)` uses custom version handler
- [x] `.version('1.2.3')` string override still works (existing behavior)
- [x] Per-option `formatHelpText` callback renders custom help text
- [x] All existing tests pass (166 tests)
- [x] Type tests pass
- [x] Build succeeds

https://claude.ai/code/session_01MozPZoR4R6mtvEkLeP2iVF