### PR TITLE
Add pkg.pr.new workflow

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -16,6 +16,7 @@ on:
 # Minimal permissions by default
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   NX_NO_CLOUD: true
@@ -74,4 +75,4 @@ jobs:
         run: pnpm nx run-many -t build
 
       - name: Publish PR branch to pkg.pr.new
-        run: pnpm dlx pkg-pr-new publish --pnpm --compact --peerDeps --no-template --comment=off './packages/*'
+        run: pnpm dlx pkg-pr-new publish --pnpm --compact --peerDeps --no-template --comment=update './packages/*'

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -28,6 +28,29 @@ jobs:
     if: github.actor == 'AgentEnder' && github.event.review.state == 'commented' && github.event.review.body == '@pkg-pr-new publish'
     runs-on: ubuntu-latest
     steps:
+      - name: React with eyes to review comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Find the timeline comment associated with this review
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+            });
+            // The review body appears as the last comment matching our trigger text
+            const triggerComment = comments.reverse().find(c => c.body.trim() === '@pkg-pr-new publish');
+            if (triggerComment) {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: triggerComment.id,
+                content: 'eyes',
+              });
+              core.exportVariable('TRIGGER_COMMENT_ID', triggerComment.id);
+            }
+
       - name: Print review comment SHA
         run: echo "${{ github.event.review.commit_id }}"
 
@@ -76,3 +99,19 @@ jobs:
 
       - name: Publish PR branch to pkg.pr.new
         run: pnpm dlx pkg-pr-new publish --pnpm --compact --peerDeps --no-template --comment=update './packages/*'
+
+      - name: React with check to review comment
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commentId = process.env.TRIGGER_COMMENT_ID;
+            if (commentId) {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(commentId),
+                content: 'rocket',
+              });
+            }

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,77 @@
+# WARNING: This workflow can be run on forks, so it is important to not perform any sensitive operations
+# or expose any secrets.
+#
+# pkg.pr.new as a registry is not the source of truth for the packages, npm is, so even if somehow a
+# malicious actor were able to leverage this workflow to publish malware, nobody would receive it
+# automatically, they would have to install a super specific URL.
+
+name: Publish PR branch to pkg.pr.new
+
+run-name: Publish PR branch to pkg.pr.new for PR ${{ github.event.pull_request.number }}
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+# Minimal permissions by default
+permissions:
+  contents: read
+
+env:
+  NX_NO_CLOUD: true
+  NX_CLOUD_ACCESS_TOKEN: ''
+
+jobs:
+  publish_pr_branch_to_pkg_pr_new:
+    name: Publish PR branch to pkg.pr.new
+    if: github.actor == 'AgentEnder' && github.event.review.state == 'commented' && github.event.review.body == '@pkg-pr-new publish'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print review comment SHA
+        run: echo "${{ github.event.review.commit_id }}"
+
+      - name: Print pull request URL
+        run: echo "${{ github.event.pull_request.html_url }}"
+
+      # Check out the PR branch HEAD as a shallow clone
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          # Disable caching given this workflow could be run on forks (security risk)
+          cache: ''
+
+      - name: Check PR branch HEAD has not changed since review comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = ${{ github.event.pull_request.number }};
+            const response = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const headSha = response.data.head.sha;
+            console.log(`The latest commit SHA on PR #${prNumber} is ${headSha}`);
+            if (headSha !== '${{ github.event.review.commit_id }}') {
+              throw new Error('PR branch HEAD has changed since the triggering review comment was made')
+            }
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
+      - name: Build packages
+        run: pnpm nx run-many -t build
+
+      - name: Publish PR branch to pkg.pr.new
+        run: pnpm dlx pkg-pr-new publish --pnpm --compact --peerDeps --no-template --comment=off './packages/*'


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow for publishing PR branches to [pkg.pr.new](https://pkg.pr.new)
- Triggered by a review comment from `AgentEnder` with `@pkg-pr-new publish`
- Includes a safety check to ensure the PR HEAD hasn't changed since the review comment
- Publishes all packages under `./packages/*`

## Test plan
- [ ] Verify workflow file is valid YAML
- [ ] Open a test PR and trigger with a `@pkg-pr-new publish` review comment
- [ ] Confirm packages are published to pkg.pr.new registry

https://claude.ai/code/session_015iWfqSPN87RvtrREyVgH1T