### PR TITLE
testing(cli-forge): pass clack fixture config via env var for Windows compat

### DIFF
--- a/e2e/fixtures/clack-prompting.ts
+++ b/e2e/fixtures/clack-prompting.ts
@@ -24,7 +24,9 @@ interface Config {
   inputs: string[];
 }
 
-const config: Config = JSON.parse(process.argv[2] || '{}');
+const config: Config = JSON.parse(
+  process.env['CLACK_FIXTURE_CONFIG'] || process.argv[2] || '{}'
+);
 
 // --- Fake TTY streams for clack ---
 const input = new Readable({ read() {} }) as any;

--- a/e2e/tests/prompting.spec.ts
+++ b/e2e/tests/prompting.spec.ts
@@ -32,8 +32,11 @@ function runPromptingExample(cliArgs: string, stdin?: string) {
  */
 async function runClackFixture(cliArgs: string[], inputs: string[]) {
   const config = JSON.stringify({ cliArgs, inputs });
-  const command = `npx tsx --no-cache ${fixturesDir}/clack-prompting.ts '${config}'`;
-  const { stdout, stderr } = await runCommand(command, [], { cwd: repoRoot });
+  const command = `npx tsx --no-cache ${fixturesDir}/clack-prompting.ts`;
+  const { stdout, stderr } = await runCommand(command, [], {
+    cwd: repoRoot,
+    env: { ...process.env, CLACK_FIXTURE_CONFIG: config },
+  });
   return { stdout, tui: renderTerminalOutput(stderr) };
 }
 


### PR DESCRIPTION
  Single quotes around JSON args are not stripped by cmd.exe on Windows,
  causing JSON.parse to fail. Use an environment variable instead to
  avoid all shell quoting issues cross-platform.

  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>