### PR TITLE
fix(cli-forge): resolve CLI module paths from cwd in import() fallback

### DIFF
--- a/packages/cli-forge/src/bin/commands/generate-documentation.ts
+++ b/packages/cli-forge/src/bin/commands/generate-documentation.ts
@@ -583,7 +583,12 @@ async function loadCLIModule(
     }
   } catch {
     try {
-      return await import(cliPath);
+      // Resolve relative paths to absolute file:// URLs so ESM import()
+      // resolves from cwd, not from this file's location in node_modules.
+      const importSpecifier = isAbsolute(cliPath)
+        ? pathToFileURL(cliPath).href
+        : pathToFileURL(join(process.cwd(), cliPath)).href;
+      return await import(importSpecifier);
     } catch (e) {
       if (cliPath.endsWith('.ts')) {
         console.warn(

--- a/packages/cli-forge/src/bin/commands/generate-documentation.ts
+++ b/packages/cli-forge/src/bin/commands/generate-documentation.ts
@@ -569,7 +569,7 @@ async function loadCLIModule(
     if (moduleType === 'esm') {
       const tsx = (await import('tsx/esm/api')) as typeof import('tsx/esm/api');
       return tsx.tsImport(cliPath, {
-        tsconfig: args.tsconfig,
+        ...(args.tsconfig ? { tsconfig: args.tsconfig } : {}),
         parentURL: pathToFileURL(
           join(process.cwd(), 'fake-file-for-import.ts')
         ).toString(),


### PR DESCRIPTION
The fallback `import(cliPath)` resolved relative paths from the cli-forge module location inside node_modules, not from process.cwd(). This broke `generate-documentation` under pnpm strict isolation where cli-forge lives deep in .pnpm/.

Convert relative paths to absolute file:// URLs before importing so resolution always starts from the caller's working directory. Works for both ESM and CJS target modules.