### PR TITLE
feat(parser): add default config path and constructor-based .config() API

### DIFF
--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -188,38 +188,11 @@ Where the config file gets created depends on what kind of tool you're building:
 
 **Project tools** (linters, bundlers, test runners) — config lives at the project root, similar to `tsconfig.json` or `.prettierrc.json`. Users expect to find it next to `package.json` or `.git`. Since users may run the CLI from a subdirectory, walk up the tree to find the root:
 
-```typescript
-import { existsSync } from 'fs';
-import { dirname, join } from 'path';
-
-function findProjectRoot(from = process.cwd()): string {
-  let dir = from;
-  while (true) {
-    if (existsSync(join(dir, 'package.json')) || existsSync(join(dir, '.git'))) {
-      return dir;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) return from; // reached filesystem root, fall back to cwd
-    dir = parent;
-  }
-}
-
-.config(ConfigurationFiles.JsonFileConfigLoader, {
-  filename: 'my-tool.config.json',
-  default: () => join(findProjectRoot(), 'my-tool.config.json'),
-})
-```
+<%= example('config-patterns').region('find-project-root') %>
 
 **User-level tools** (CLIs installed globally, developer utilities, personal tools) — config lives in the user's home directory. Following the [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) convention, use `~/.config/`:
 
-```typescript
-import { homedir } from 'os';
-
-.config(ConfigurationFiles.JsonFileConfigLoader, {
-  filename: 'my-tool.json',
-  default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
-})
-```
+<%= example('config-patterns').region('user-level') %>
 
 Your users would then see:
 
@@ -230,24 +203,7 @@ Config written to ~/.config/my-tool/config.json
 
 **Hybrid tools** — some tools support both project-level and user-level config, with project config taking precedence. Register two providers — the project-level one resolves first, and the user-level one acts as a fallback:
 
-```typescript
-import { homedir } from 'os';
-
-cli('my-tool', {
-  builder: (args) =>
-    args
-      .option('theme', { type: 'string' })
-      // Project config — checked first
-      .config(ConfigurationFiles.JsonFileConfigLoader, {
-        filename: 'my-tool.config.json',
-      })
-      // User config — fallback, with a default for init
-      .config(ConfigurationFiles.JsonFileConfigLoader, {
-        filename: 'my-tool.json',
-        default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
-      }),
-});
-```
+<%= example('config-patterns').region('hybrid') %>
 
 The `default` option accepts a string path, a `URL`, or a function returning either (sync or async). The provider classes are available from the `ConfigurationFiles` namespace:
 
@@ -261,15 +217,7 @@ import { ConfigurationFiles } from 'cli-forge';
 
 **How to build it:** Call `app.updateConfig()` from any command handler:
 
-```typescript
-// Partial update — only the specified keys change
-await app.updateConfig({ theme: 'dark' });
-
-// Updater function — read-modify-write
-await app.updateConfig((config) => {
-  config.theme = config.theme === 'dark' ? 'light' : 'dark';
-});
-```
+<%= example('config-patterns').region('update-config') %>
 
 When multiple providers are registered, updates route to the correct file. Each key is written to whichever provider originally supplied it:
 
@@ -292,30 +240,9 @@ Your users can set baseline values in a config file and override any of them fro
 
 ## Custom configuration providers
 
-If JSON and `package.json` don't fit your needs — for example, YAML or TOML configs — implement the `ConfigurationProvider` interface:
+If JSON and `package.json` don't fit your needs, implement the `ConfigurationProvider` interface. Here's a working key-value config loader that reads `key=value` files:
 
-```typescript
-import { ConfigurationFiles } from 'cli-forge';
-
-class YamlConfigLoader<T>
-  implements ConfigurationFiles.ConfigurationProvider<T, string>
-{
-  resolve(configurationRoot: string): string | undefined {
-    // Walk up directory tree looking for the config file
-  }
-
-  load(filename: string): T & { extends?: string } {
-    // Parse and return the config object
-  }
-
-  async updateConfig(
-    configOrUpdater: T | ((current: T) => T | Promise<T>),
-    options?: { targetPath?: string }
-  ): Promise<void> {
-    // Write updated config back to disk
-  }
-}
-```
+<%= example('config-patterns').region('custom-provider') %>
 
 The interface requires `resolve` and `load`. The `updateConfig` and `describeConfig` methods are optional.
 

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -1,57 +1,109 @@
 ---
 title: Configuration Files
-description: Load, merge, inherit, and update CLI configuration from JSON files and package.json
+description: Let your CLI users store settings in config files instead of passing flags on every invocation
 nav:
   order: 5
 ---
 
 # Configuration files
 
-CLI Forge can load argument values from configuration files, letting users set defaults in a file instead of passing every flag on every invocation. This is the same pattern used by tools like ESLint, Prettier, and TypeScript.
+Adding config file support to your CLI means users can store their preferred settings once and skip repeating flags on every invocation. Instead of:
 
-The sections below cover two perspectives: **building** a CLI that supports config files, and the **user experience** those config files enable.
+```bash
+my-tool --host localhost --port 8080 --debug --log-level verbose
+```
 
-## Registering configuration providers
+They create a config file and run:
 
-Use `.config()` with a built-in provider to register a configuration source:
+```bash
+my-tool
+```
 
-<%= example('configuration-files').region('providers') %>
+CLI Forge supports several configuration styles. Each one gives your users a different experience — pick the ones that match how your tool will be used.
 
-CLI Forge ships two built-in providers:
+## Dedicated config file
 
-- **`ConfigurationProviders.JsonFile(filename, key?)`** — loads values from a JSON file. If `key` is provided, reads from that property instead of the root object.
-- **`ConfigurationProviders.PackageJson(key)`** — loads values from a `key` inside the project's `package.json`.
+**What your users see:** A JSON file named after your tool, checked into the project root. Similar to `tsconfig.json`, `.prettierrc.json`, or `eslint.config.json`.
 
-You can register multiple providers. They are checked in registration order, and the first provider that supplies a value for a given key wins.
+```
+my-project/
+├── my-tool.config.json    ← config lives here
+├── package.json
+└── src/
+```
 
-## How config loading works
+```json
+{
+  "host": "localhost",
+  "port": 8080,
+  "debug": true
+}
+```
 
-When your CLI runs, the parser resolves configuration in a specific order.
+Running `my-tool` from anywhere inside the project picks up these values. The file is found by walking up the directory tree from the working directory, so `cd my-project/src && my-tool` still works.
 
-### Resolution pipeline
+**How to build it:**
 
-For each registered provider, the framework:
+```typescript
+import { cli, ConfigurationProviders } from 'cli-forge';
 
-1. **Resolves** — walks up the directory tree from the working directory looking for the config file
-2. **Loads** — reads and parses the file
-3. **Follows extends** — if the loaded config has an `"extends"` field, recursively loads the parent and merges
-4. **Merges** — combines values from all providers (first-registered wins on conflicts)
-5. **Yields to higher-precedence sources** — CLI args and env vars override config values
+cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('host', { type: 'string', default: 'localhost' })
+      .option('port', { type: 'number', default: 3000 })
+      .option('debug', { type: 'boolean', default: false })
+      .config(ConfigurationProviders.JsonFile('my-tool.config.json')),
+  handler: (args) => {
+    // args.host, args.port, args.debug are populated from the config file
+  },
+});
+```
 
-### Value precedence
+If the config should live under a key instead of at the root of the JSON file, pass the key name as the second argument:
 
-When the same option has values from multiple sources, CLI Forge applies this precedence (highest wins):
+```typescript
+// Reads from { "my-tool": { "host": "...", "port": ... } }
+.config(ConfigurationProviders.JsonFile('other.config.json', 'my-tool'))
+```
 
-1. **CLI arguments** — explicit flags always take priority
-2. **Environment variables** — if env is configured for the option
-3. **Configuration files** — in registration order
-4. **Default values** — from option definitions
+## `package.json` key
 
-This means a user can set baseline values in a config file and override specific ones on the command line. The precedence follows the principle of specificity: CLI arguments are the most intentional, defaults are the least.
+**What your users see:** Configuration lives inside `package.json` under a key. No extra file needed. Similar to how Jest uses `"jest"` and Babel uses `"babel"` in `package.json`.
 
-## Multiple providers and precedence
+```json
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "my-tool": {
+    "host": "localhost",
+    "port": 8080
+  }
+}
+```
 
-When you register multiple config providers, CLI Forge merges their values. The first provider to supply a value for a given key wins — later providers only contribute keys that haven't been set yet.
+This works well for tools with a small number of options where adding a separate file feels heavy.
+
+**How to build it:**
+
+```typescript
+.config(ConfigurationProviders.PackageJson('my-tool'))
+```
+
+## Multiple config sources
+
+**What your users see:** The tool checks several places for configuration. Users put settings wherever makes sense for their project — a dedicated config file, `package.json`, or both.
+
+```
+my-project/
+├── my-tool.config.json    ← tool-specific settings
+├── package.json           ← also has a "my-tool" key
+└── src/
+```
+
+When the same key appears in multiple sources, the first registered provider wins. Non-conflicting keys merge from all sources.
+
+**How to build it:**
 
 <%= example('multi-provider-precedence').file('cli.ts') %>
 
@@ -65,82 +117,126 @@ Given these config files:
 { "name": "from-json", "greeting": "json-greeting" }
 ```
 
-The resolved config is:
+The resolved values are:
 - `name`: `"from-package"` — PackageJson was registered first, so it wins
-- `greeting`: `"json-greeting"` — only in JsonFile
-- `farewell`: `"pkg-farewell"` — only in PackageJson
+- `greeting`: `"json-greeting"` — only in the JSON file
+- `farewell`: `"pkg-farewell"` — only in package.json
 
-Non-conflicting values merge from all providers. You can split configuration across files — for example, project-level settings in `package.json` and tool-specific settings in a dedicated config file.
+## Shareable and inheritable configs
 
-## Configuration inheritance with `extends`
+**What your users see:** A base config that other configs extend, just like `tsconfig.json` with `"extends"`. Teams publish a shared config package or keep a base config in the repo root, and individual projects override specific values.
 
-Config files support an `"extends"` field to inherit values from another file:
+```json
+// base.config.json — shared team defaults
+{
+  "host": "0.0.0.0",
+  "port": 3000,
+  "debug": false
+}
+```
+
+```json
+// my-tool.config.json — project overrides
+{
+  "extends": "./base.config.json",
+  "port": 8080,
+  "debug": true
+}
+```
+
+The project config inherits `host` from the base and overrides `port` and `debug`. Extends chains can go arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error.
+
+**How to build it:** No extra code needed — `extends` works automatically with any JSON file provider.
+
+<%= example('config-inheritance').file('cli.ts') %>
 
 <%= example('config-inheritance').file('app.config.json') %>
 
 <%= example('config-inheritance').file('base/app.config.json') %>
 
-The child config inherits all values from the base and can override any of them. The `extends` path is resolved relative to the file that declares it. Common patterns:
+## Init commands and config bootstrapping
 
-- **Shared team configurations** — a base config checked into the repo, with per-developer overrides in a local file
-- **Environment-specific configs** — a base config with production/staging/development overlays
-- **Monorepo presets** — a root config that workspace packages extend
+**What your users see:** An `init` command that creates a config file with sensible defaults, so users don't have to write JSON by hand.
 
-Extends chains can be arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error instead of looping.
+```bash
+$ my-tool init --theme dark --lang fr
+Config written to my-tool.config.json
 
-## Constructor-based provider registration
+$ cat my-tool.config.json
+{
+  "theme": "dark",
+  "lang": "fr"
+}
+```
 
-For more control over provider behavior, use the constructor-based `.config()` overload. This accepts a provider class and an options object:
+After that, running `my-tool` picks up the config automatically. Users can also update individual values:
+
+```bash
+$ my-tool set --key theme --value light
+Set theme = light
+```
+
+**How to build it:** Use the constructor-based `.config()` overload with a `default` option. The `default` tells the framework where to create the config file when none exists on disk.
 
 <%= example('default-config').region('init-command') %>
 
-The constructor-based form supports a `default` option that tells the framework where to create a config file when none exists on disk. This is essential for `init` commands — without it, `updateConfig` would have no file to write to.
+Without `default`, `updateConfig` would fail because there's no file to write to. The `default` option accepts a string path, a `URL`, or a function returning either:
 
-The `default` option accepts:
-- A **string path**: `default: join(process.cwd(), 'app.config.json')`
-- A **URL**: `default: new URL('./app.config.json', import.meta.url)`
-- A **function** returning either (sync or async): `default: () => join(cwd(), 'app.config.json')`
+```typescript
+// Static path
+default: join(process.cwd(), 'my-tool.config.json')
 
-The provider classes are available from the `ConfigurationFiles` namespace:
+// URL (for ESM)
+default: new URL('./my-tool.config.json', import.meta.url)
+
+// Deferred function
+default: () => join(process.cwd(), 'my-tool.config.json')
+```
+
+The provider classes (`JsonFileConfigLoader`, `PackageJsonConfigLoader`) are available from the `ConfigurationFiles` namespace:
 
 ```typescript
 import { ConfigurationFiles } from 'cli-forge';
-
-// ConfigurationFiles.JsonFileConfigLoader
-// ConfigurationFiles.PackageJsonConfigLoader
 ```
 
-## Writing configuration back
+## Updating config from code
 
-Use `.updateConfig()` to persist values back to configuration files. This powers `init` commands, setup wizards, and `config set` commands:
+**What your users see:** Commands that persist settings to the config file. Changes survive between invocations.
+
+**How to build it:** Call `app.updateConfig()` from any command handler:
 
 ```typescript
-// Write a partial update — only the specified keys are changed
+// Partial update — only the specified keys change
 await app.updateConfig({ theme: 'dark' });
 
-// Or use an updater function for read-modify-write
+// Updater function — read-modify-write
 await app.updateConfig((config) => {
   config.theme = config.theme === 'dark' ? 'light' : 'dark';
 });
 ```
 
-### How updates are routed
-
-When multiple providers are registered, `updateConfig` routes each key to the provider that originally supplied it. This means updating `greeting` writes to whichever file `greeting` was loaded from, not necessarily the first file.
+When multiple providers are registered, updates route to the correct file. Each key is written to whichever provider originally supplied it:
 
 <%= example('multi-provider-precedence').file('update-test.ts') %>
 
-Keys that weren't in any config file (new keys) are written to the first provider that has a resolved file on disk. If no provider resolves — for example, when no config file exists yet — the framework falls back to the first provider with a `default` path configured and creates the file.
-
-### Updates with `extends`
-
-When a config file uses `extends`, updates are written to the child file (the one that declares `extends`), not the parent. Inherited values that are updated get a local copy in the child file, and the `extends` reference is preserved.
+When a config file uses `extends`, updates are written to the child file (not the parent), and the `extends` reference is preserved:
 
 <%= example('config-inheritance').file('update-test.ts') %>
 
+## Value precedence
+
+Across all configuration styles, CLI Forge applies a consistent precedence (highest wins):
+
+1. **CLI arguments** — explicit flags always take priority
+2. **Environment variables** — if env is configured for the option
+3. **Configuration files** — in registration order
+4. **Default values** — from option definitions
+
+Your users can set baseline values in a config file and override any of them from the command line on a per-invocation basis. The precedence follows specificity: CLI arguments are the most intentional, defaults are the least.
+
 ## Custom configuration providers
 
-If JSON files and `package.json` don't fit your needs, implement the `ConfigurationProvider` interface to load config from any source:
+If JSON and `package.json` don't fit your needs — for example, YAML or TOML configs — implement the `ConfigurationProvider` interface:
 
 ```typescript
 import { ConfigurationFiles } from 'cli-forge';
@@ -149,14 +245,13 @@ class YamlConfigLoader<T>
   implements ConfigurationFiles.ConfigurationProvider<T, string>
 {
   resolve(configurationRoot: string): string | undefined {
-    // Search for the config file from configurationRoot upward
+    // Walk up directory tree looking for the config file
   }
 
   load(filename: string): T & { extends?: string } {
     // Parse and return the config object
   }
 
-  // Optional: enable updateConfig support
   async updateConfig(
     configOrUpdater: T | ((current: T) => T | Promise<T>),
     options?: { targetPath?: string }
@@ -166,56 +261,18 @@ class YamlConfigLoader<T>
 }
 ```
 
-The interface has two required methods (`resolve` and `load`) and two optional ones (`updateConfig` and `describeConfig`). The `TLocation` type parameter (second generic, defaults to `string | URL`) controls the path type used by `resolve` and `load`.
+The interface requires `resolve` and `load`. The `updateConfig` and `describeConfig` methods are optional.
 
-## What your users get
+## Choosing a configuration style
 
-When you add config file support to your CLI, your users get several capabilities without any extra work on your part:
-
-### Zero-flag invocations
-
-Instead of typing every option:
-
-```bash
-my-tool --host localhost --port 8080 --debug --log-level verbose
-```
-
-Users create a config file once and just run:
-
-```bash
-my-tool
-```
-
-### Per-project configuration
-
-The config file lives in the project directory and can be checked into source control. Every developer on the team gets the same defaults.
-
-### Layered overrides
-
-Users can set team defaults in a base config, override per-project or per-environment with `extends`, and still override anything from the command line. The precedence chain (CLI args > env vars > config files > defaults) gives them fine-grained control.
-
-### Init and set commands
-
-If you use the `default` option and expose `updateConfig` through commands, users get interactive setup:
-
-```bash
-# Bootstrap a config file
-my-tool init --theme dark --lang fr
-
-# Tweak individual values
-my-tool set --key theme --value light
-```
-
-## When to use configuration files
-
-| Scenario | Recommendation |
-|---|---|
-| Many options with stable defaults | Use a JSON config file |
-| Project-level settings shared in source control | Use a `package.json` key |
-| Team base config with personal overrides | Use `extends` inheritance |
-| One-off flags | Stick with CLI arguments |
-| Setup wizard or init command | Use `default` + `updateConfig` |
-| Non-JSON config format | Implement a custom provider |
+| Your users need | Configuration style | Provider |
+|---|---|---|
+| A dedicated config file like `tsconfig.json` | Dedicated config file | `ConfigurationProviders.JsonFile(filename)` |
+| Settings in `package.json` without extra files | package.json key | `ConfigurationProviders.PackageJson(key)` |
+| Multiple places to put config | Multiple sources | Register several providers |
+| A team base config with project overrides | Inheritable configs | Add `"extends"` to any JSON config |
+| A `my-tool init` command | Init/bootstrap | Use `default` + `updateConfig` |
+| YAML, TOML, or another format | Custom provider | Implement `ConfigurationProvider` |
 
 For complete working examples with test assertions, see:
 

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Files
-description: Load CLI arguments from JSON files and package.json
+description: Load, merge, inherit, and update CLI configuration from JSON files and package.json
 nav:
   order: 5
 ---
@@ -8,6 +8,8 @@ nav:
 # Configuration files
 
 CLI Forge can load argument values from configuration files, letting users set defaults in a file instead of passing every flag on every invocation. This is the same pattern used by tools like ESLint, Prettier, and TypeScript.
+
+The sections below cover two perspectives: **building** a CLI that supports config files, and the **user experience** those config files enable.
 
 ## Registering configuration providers
 
@@ -20,69 +22,203 @@ CLI Forge ships two built-in providers:
 - **`ConfigurationProviders.JsonFile(filename, key?)`** — loads values from a JSON file. If `key` is provided, reads from that property instead of the root object.
 - **`ConfigurationProviders.PackageJson(key)`** — loads values from a `key` inside the project's `package.json`.
 
-You can register multiple providers. They are checked in registration order, and the first provider that supplies a value for a given option wins.
+You can register multiple providers. They are checked in registration order, and the first provider that supplies a value for a given key wins.
 
-## Value precedence
+## How config loading works
+
+When your CLI runs, the parser resolves configuration in a specific order.
+
+### Resolution pipeline
+
+For each registered provider, the framework:
+
+1. **Resolves** — walks up the directory tree from the working directory looking for the config file
+2. **Loads** — reads and parses the file
+3. **Follows extends** — if the loaded config has an `"extends"` field, recursively loads the parent and merges
+4. **Merges** — combines values from all providers (first-registered wins on conflicts)
+5. **Yields to higher-precedence sources** — CLI args and env vars override config values
+
+### Value precedence
 
 When the same option has values from multiple sources, CLI Forge applies this precedence (highest wins):
 
 1. **CLI arguments** — explicit flags always take priority
-2. **Environment variables** — if env is configured
+2. **Environment variables** — if env is configured for the option
 3. **Configuration files** — in registration order
 4. **Default values** — from option definitions
 
-This means a user can set baseline values in a config file and override specific ones on the command line.
+This means a user can set baseline values in a config file and override specific ones on the command line. The precedence follows the principle of specificity: CLI arguments are the most intentional, defaults are the least.
+
+## Multiple providers and precedence
+
+When you register multiple config providers, CLI Forge merges their values. The first provider to supply a value for a given key wins — later providers only contribute keys that haven't been set yet.
+
+<%= example('multi-provider-precedence').file('cli.ts') %>
+
+Given these config files:
+
+```json
+// package.json
+{ "my-app": { "name": "from-package", "farewell": "pkg-farewell" } }
+
+// app.config.json
+{ "name": "from-json", "greeting": "json-greeting" }
+```
+
+The resolved config is:
+- `name`: `"from-package"` — PackageJson was registered first, so it wins
+- `greeting`: `"json-greeting"` — only in JsonFile
+- `farewell`: `"pkg-farewell"` — only in PackageJson
+
+Non-conflicting values merge from all providers. You can split configuration across files — for example, project-level settings in `package.json` and tool-specific settings in a dedicated config file.
 
 ## Configuration inheritance with `extends`
 
-Config files support an `extends` field to inherit values from another file:
+Config files support an `"extends"` field to inherit values from another file:
 
-```json
-{
-  "extends": "./base-config.json",
-  "port": 8080
-}
+<%= example('config-inheritance').file('app.config.json') %>
+
+<%= example('config-inheritance').file('base/app.config.json') %>
+
+The child config inherits all values from the base and can override any of them. The `extends` path is resolved relative to the file that declares it. Common patterns:
+
+- **Shared team configurations** — a base config checked into the repo, with per-developer overrides in a local file
+- **Environment-specific configs** — a base config with production/staging/development overlays
+- **Monorepo presets** — a root config that workspace packages extend
+
+Extends chains can be arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error instead of looping.
+
+## Constructor-based provider registration
+
+For more control over provider behavior, use the constructor-based `.config()` overload. This accepts a provider class and an options object:
+
+<%= example('default-config').region('init-command') %>
+
+The constructor-based form supports a `default` option that tells the framework where to create a config file when none exists on disk. This is essential for `init` commands — without it, `updateConfig` would have no file to write to.
+
+The `default` option accepts:
+- A **string path**: `default: join(process.cwd(), 'app.config.json')`
+- A **URL**: `default: new URL('./app.config.json', import.meta.url)`
+- A **function** returning either (sync or async): `default: () => join(cwd(), 'app.config.json')`
+
+The provider classes are available from the `ConfigurationFiles` namespace:
+
+```typescript
+import { ConfigurationFiles } from 'cli-forge';
+
+// ConfigurationFiles.JsonFileConfigLoader
+// ConfigurationFiles.PackageJsonConfigLoader
 ```
-
-```json
-{
-  "host": "localhost",
-  "port": 3000,
-  "debug": false
-}
-```
-
-The child config inherits all values from `base-config.json` and overrides `port`. This enables shared team configurations with per-developer or per-environment overrides.
-
-CLI Forge detects circular `extends` references and throws a clear error instead of looping forever.
 
 ## Writing configuration back
 
-Use `.updateConfig()` to persist values back to a configuration file. This is useful for `init` commands or setup wizards:
+Use `.updateConfig()` to persist values back to configuration files. This powers `init` commands, setup wizards, and `config set` commands:
 
 ```typescript
-const app = cli('my-tool')
-  .option('theme', { type: 'string', default: 'light' })
-  .config(ConfigurationProviders.JsonFile('my-tool.config.json'))
-  .command('set-theme', {
-    builder: (cmd) =>
-      cmd.option('value', { type: 'string', required: true }),
-    handler: async (args) => {
-      await args.updateConfig({ theme: args.value });
-      console.log(`Theme set to ${args.value}`);
-    },
-  });
+// Write a partial update — only the specified keys are changed
+await app.updateConfig({ theme: 'dark' });
+
+// Or use an updater function for read-modify-write
+await app.updateConfig((config) => {
+  config.theme = config.theme === 'dark' ? 'light' : 'dark';
+});
 ```
 
-The update is written to the first provider that supports writing (JSON file providers do, package.json does not).
+### How updates are routed
+
+When multiple providers are registered, `updateConfig` routes each key to the provider that originally supplied it. This means updating `greeting` writes to whichever file `greeting` was loaded from, not necessarily the first file.
+
+<%= example('multi-provider-precedence').file('update-test.ts') %>
+
+Keys that weren't in any config file (new keys) are written to the first provider that has a resolved file on disk. If no provider resolves — for example, when no config file exists yet — the framework falls back to the first provider with a `default` path configured and creates the file.
+
+### Updates with `extends`
+
+When a config file uses `extends`, updates are written to the child file (the one that declares `extends`), not the parent. Inherited values that are updated get a local copy in the child file, and the `extends` reference is preserved.
+
+<%= example('config-inheritance').file('update-test.ts') %>
+
+## Custom configuration providers
+
+If JSON files and `package.json` don't fit your needs, implement the `ConfigurationProvider` interface to load config from any source:
+
+```typescript
+import { ConfigurationFiles } from 'cli-forge';
+
+class YamlConfigLoader<T>
+  implements ConfigurationFiles.ConfigurationProvider<T, string>
+{
+  resolve(configurationRoot: string): string | undefined {
+    // Search for the config file from configurationRoot upward
+  }
+
+  load(filename: string): T & { extends?: string } {
+    // Parse and return the config object
+  }
+
+  // Optional: enable updateConfig support
+  async updateConfig(
+    configOrUpdater: T | ((current: T) => T | Promise<T>),
+    options?: { targetPath?: string }
+  ): Promise<void> {
+    // Write updated config back to disk
+  }
+}
+```
+
+The interface has two required methods (`resolve` and `load`) and two optional ones (`updateConfig` and `describeConfig`). The `TLocation` type parameter (second generic, defaults to `string | URL`) controls the path type used by `resolve` and `load`.
+
+## What your users get
+
+When you add config file support to your CLI, your users get several capabilities without any extra work on your part:
+
+### Zero-flag invocations
+
+Instead of typing every option:
+
+```bash
+my-tool --host localhost --port 8080 --debug --log-level verbose
+```
+
+Users create a config file once and just run:
+
+```bash
+my-tool
+```
+
+### Per-project configuration
+
+The config file lives in the project directory and can be checked into source control. Every developer on the team gets the same defaults.
+
+### Layered overrides
+
+Users can set team defaults in a base config, override per-project or per-environment with `extends`, and still override anything from the command line. The precedence chain (CLI args > env vars > config files > defaults) gives them fine-grained control.
+
+### Init and set commands
+
+If you use the `default` option and expose `updateConfig` through commands, users get interactive setup:
+
+```bash
+# Bootstrap a config file
+my-tool init --theme dark --lang fr
+
+# Tweak individual values
+my-tool set --key theme --value light
+```
 
 ## When to use configuration files
 
 | Scenario | Recommendation |
 |---|---|
 | Many options with stable defaults | Use a JSON config file |
-| Project-level settings shared in source control | Use package.json key |
+| Project-level settings shared in source control | Use a `package.json` key |
 | Team base config with personal overrides | Use `extends` inheritance |
 | One-off flags | Stick with CLI arguments |
+| Setup wizard or init command | Use `default` + `updateConfig` |
+| Non-JSON config format | Implement a custom provider |
 
-For the complete working example with test assertions, see the [configuration files example](/examples/configuration-files).
+For complete working examples with test assertions, see:
+
+- [Configuration files](/examples/configuration-files) — basic provider setup
+- [Config inheritance](/examples/config-inheritance) — extends and updateConfig
+- [Multi-provider precedence](/examples/multi-provider-precedence) — merging across providers

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -186,12 +186,27 @@ Without `default`, `updateConfig` would fail because there's no file to write to
 
 Where the config file gets created depends on what kind of tool you're building:
 
-**Project tools** (linters, bundlers, test runners) — config lives in the project directory, similar to `tsconfig.json` or `.prettierrc.json`. Users expect to find it next to `package.json`:
+**Project tools** (linters, bundlers, test runners) — config lives at the project root, similar to `tsconfig.json` or `.prettierrc.json`. Users expect to find it next to `package.json` or `.git`. Since users may run the CLI from a subdirectory, walk up the tree to find the root:
 
 ```typescript
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+
+function findProjectRoot(from = process.cwd()): string {
+  let dir = from;
+  while (true) {
+    if (existsSync(join(dir, 'package.json')) || existsSync(join(dir, '.git'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return from; // reached filesystem root, fall back to cwd
+    dir = parent;
+  }
+}
+
 .config(ConfigurationFiles.JsonFileConfigLoader, {
   filename: 'my-tool.config.json',
-  default: () => join(process.cwd(), 'my-tool.config.json'),
+  default: () => join(findProjectRoot(), 'my-tool.config.json'),
 })
 ```
 

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -146,7 +146,7 @@ The resolved values are:
 
 The project config inherits `host` from the base and overrides `port` and `debug`. Extends chains can go arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error.
 
-**How to build it:** No extra code needed — `extends` works automatically with any JSON file provider.
+**How to build it:** No extra code needed — `extends` works automatically with any configuration provider. The framework handles inheritance at the aggregate level, so custom providers get it for free.
 
 <%= example('config-inheritance').file('cli.ts') %>
 

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -32,63 +32,29 @@ my-project/
 └── src/
 ```
 
-```json
-{
-  "host": "localhost",
-  "port": 8080,
-  "debug": true
-}
-```
+<%= example('configuration-files').file('configured-cli.config.json') %>
 
 Running `my-tool` from anywhere inside the project picks up these values. The file is found by walking up the directory tree from the working directory, so `cd my-project/src && my-tool` still works.
 
 **How to build it:**
 
-```typescript
-import { cli, ConfigurationProviders } from 'cli-forge';
-
-cli('my-tool', {
-  builder: (args) =>
-    args
-      .option('host', { type: 'string', default: 'localhost' })
-      .option('port', { type: 'number', default: 3000 })
-      .option('debug', { type: 'boolean', default: false })
-      .config(ConfigurationProviders.JsonFile('my-tool.config.json')),
-  handler: (args) => {
-    // args.host, args.port, args.debug are populated from the config file
-  },
-});
-```
+<%= example('configuration-files').region('json-file-config') %>
 
 If the config should live under a key instead of at the root of the JSON file, pass the key name as the second argument:
 
-```typescript
-// Reads from { "my-tool": { "host": "...", "port": ... } }
-.config(ConfigurationProviders.JsonFile('other.config.json', 'my-tool'))
-```
+<%= example('configuration-files').region('nested-key-config') %>
 
 ## `package.json` key
 
 **What your users see:** Configuration lives inside `package.json` under a key. No extra file needed. Similar to how Jest uses `"jest"` and Babel uses `"babel"` in `package.json`.
 
-```json
-{
-  "name": "my-project",
-  "version": "1.0.0",
-  "my-tool": {
-    "host": "localhost",
-    "port": 8080
-  }
-}
-```
+<%= example('configuration-files').file('package.json') %>
 
 This works well for tools with a small number of options where adding a separate file feels heavy.
 
 **How to build it:**
 
-```typescript
-.config(ConfigurationProviders.PackageJson('my-tool'))
-```
+<%= example('configuration-files').region('package-json-config') %>
 
 ## Multiple config sources
 
@@ -109,13 +75,9 @@ When the same key appears in multiple sources, the first registered provider win
 
 Given these config files:
 
-```json
-// package.json
-{ "my-app": { "name": "from-package", "farewell": "pkg-farewell" } }
+<%= example('multi-provider-precedence').file('package.json') %>
 
-// app.config.json
-{ "name": "from-json", "greeting": "json-greeting" }
-```
+<%= example('multi-provider-precedence').file('app.config.json') %>
 
 The resolved values are:
 - `name`: `"from-package"` — PackageJson was registered first, so it wins
@@ -126,33 +88,15 @@ The resolved values are:
 
 **What your users see:** A base config that other configs extend, just like `tsconfig.json` with `"extends"`. Teams publish a shared config package or keep a base config in the repo root, and individual projects override specific values.
 
-```json
-// base.config.json — shared team defaults
-{
-  "host": "0.0.0.0",
-  "port": 3000,
-  "debug": false
-}
-```
+<%= example('config-inheritance').file('base/app.config.json') %>
 
-```json
-// my-tool.config.json — project overrides
-{
-  "extends": "./base.config.json",
-  "port": 8080,
-  "debug": true
-}
-```
+<%= example('config-inheritance').file('app.config.json') %>
 
-The project config inherits `host` from the base and overrides `port` and `debug`. Extends chains can go arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error.
+The project config inherits values from the base and overrides specific keys. Extends chains can go arbitrarily deep (A extends B extends C). CLI Forge detects circular references and throws a clear error.
 
 **How to build it:** No extra code needed — `extends` works automatically with any configuration provider. The framework handles inheritance at the aggregate level, so custom providers get it for free.
 
 <%= example('config-inheritance').file('cli.ts') %>
-
-<%= example('config-inheritance').file('app.config.json') %>
-
-<%= example('config-inheritance').file('base/app.config.json') %>
 
 ## Init commands and config bootstrapping
 

--- a/docs-site/docs/guides/configuration-files.md
+++ b/docs-site/docs/guides/configuration-files.md
@@ -180,20 +180,61 @@ Set theme = light
 
 <%= example('default-config').region('init-command') %>
 
-Without `default`, `updateConfig` would fail because there's no file to write to. The `default` option accepts a string path, a `URL`, or a function returning either:
+Without `default`, `updateConfig` would fail because there's no file to write to.
+
+### Choosing the right default path
+
+Where the config file gets created depends on what kind of tool you're building:
+
+**Project tools** (linters, bundlers, test runners) — config lives in the project directory, similar to `tsconfig.json` or `.prettierrc.json`. Users expect to find it next to `package.json`:
 
 ```typescript
-// Static path
-default: join(process.cwd(), 'my-tool.config.json')
-
-// URL (for ESM)
-default: new URL('./my-tool.config.json', import.meta.url)
-
-// Deferred function
-default: () => join(process.cwd(), 'my-tool.config.json')
+.config(ConfigurationFiles.JsonFileConfigLoader, {
+  filename: 'my-tool.config.json',
+  default: () => join(process.cwd(), 'my-tool.config.json'),
+})
 ```
 
-The provider classes (`JsonFileConfigLoader`, `PackageJsonConfigLoader`) are available from the `ConfigurationFiles` namespace:
+**User-level tools** (CLIs installed globally, developer utilities, personal tools) — config lives in the user's home directory. Following the [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) convention, use `~/.config/`:
+
+```typescript
+import { homedir } from 'os';
+
+.config(ConfigurationFiles.JsonFileConfigLoader, {
+  filename: 'my-tool.json',
+  default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
+})
+```
+
+Your users would then see:
+
+```bash
+$ my-tool init
+Config written to ~/.config/my-tool/config.json
+```
+
+**Hybrid tools** — some tools support both project-level and user-level config, with project config taking precedence. Register two providers — the project-level one resolves first, and the user-level one acts as a fallback:
+
+```typescript
+import { homedir } from 'os';
+
+cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string' })
+      // Project config — checked first
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+      })
+      // User config — fallback, with a default for init
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.json',
+        default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
+      }),
+});
+```
+
+The `default` option accepts a string path, a `URL`, or a function returning either (sync or async). The provider classes are available from the `ConfigurationFiles` namespace:
 
 ```typescript
 import { ConfigurationFiles } from 'cli-forge';

--- a/examples/config-patterns/.kvconfig
+++ b/examples/config-patterns/.kvconfig
@@ -1,0 +1,3 @@
+# Key-value config example
+greeting=howdy
+name=partner

--- a/examples/config-patterns/custom-provider.ts
+++ b/examples/config-patterns/custom-provider.ts
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from 'fs';
+import { writeFile, mkdir } from 'fs/promises';
+import { dirname, join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// #region custom-provider
+class KeyValueConfigLoader<T extends Record<string, string>>
+  implements ConfigurationFiles.ConfigurationProvider<T, string>
+{
+  private readonly filename: string;
+
+  constructor(options: { filename: string }) {
+    this.filename = options.filename;
+  }
+
+  resolve(configurationRoot: string): string | undefined {
+    let dir = configurationRoot;
+    let prev: string | undefined;
+    while (prev !== dir) {
+      prev = dir;
+      const candidate = join(dir, this.filename);
+      if (existsSync(candidate)) return candidate;
+      dir = dirname(dir);
+    }
+    return undefined;
+  }
+
+  load(filepath: string): T & { extends?: string } {
+    const content = readFileSync(filepath, 'utf-8');
+    const result: Record<string, string> = {};
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIdx = trimmed.indexOf('=');
+      if (eqIdx === -1) continue;
+      result[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
+    }
+    return result as T & { extends?: string };
+  }
+
+  async updateConfig(
+    configOrUpdater: T | ((current: T) => T | Promise<T>),
+    options?: { targetPath?: string }
+  ): Promise<void> {
+    const filepath = options?.targetPath ?? this.resolve(process.cwd());
+    if (!filepath) {
+      throw new Error(`Could not resolve ${this.filename}`);
+    }
+
+    const current = existsSync(filepath)
+      ? this.load(filepath)
+      : ({} as T);
+    const updated =
+      typeof configOrUpdater === 'function'
+        ? await (configOrUpdater as (c: T) => T | Promise<T>)(current)
+        : configOrUpdater;
+
+    const lines = Object.entries(updated)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n');
+
+    await mkdir(dirname(filepath), { recursive: true });
+    await writeFile(filepath, lines + '\n');
+  }
+}
+// #endregion custom-provider
+
+(async () =>
+  await cli('kv-tool', {
+    builder: (args) =>
+      args
+        .option('greeting', { type: 'string', default: 'hello' })
+        .option('name', { type: 'string', default: 'world' })
+        .config(new KeyValueConfigLoader({ filename: '.kvconfig' })),
+    handler: (args) => {
+      console.log(`${args.greeting}, ${args.name}!`);
+    },
+  }).forge())();

--- a/examples/config-patterns/custom-provider.ts
+++ b/examples/config-patterns/custom-provider.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'path';
 import { ConfigurationFiles, cli } from 'cli-forge';
 
 // #region custom-provider
-class KeyValueConfigLoader<T extends Record<string, string>>
+class KeyValueConfigLoader<T>
   implements ConfigurationFiles.ConfigurationProvider<T, string>
 {
   private readonly filename: string;
@@ -55,7 +55,7 @@ class KeyValueConfigLoader<T extends Record<string, string>>
         ? await (configOrUpdater as (c: T) => T | Promise<T>)(current)
         : configOrUpdater;
 
-    const lines = Object.entries(updated)
+    const lines = Object.entries(updated as Record<string, unknown>)
       .map(([k, v]) => `${k}=${v}`)
       .join('\n');
 

--- a/examples/config-patterns/fresh-updater.ts
+++ b/examples/config-patterns/fresh-updater.ts
@@ -3,17 +3,11 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { ConfigurationFiles, cli } from 'cli-forge';
 
-// The updater-function form of updateConfig sees an empty object as the
-// "current" config when the default-path file does not exist yet. Use this
-// pattern when you need to read-modify-write but don't know whether the
-// config already exists.
-//
-// NOTE: the `current` value passed to the updater is derived from whatever
-// providers resolve from the current working directory. When the only file
-// on disk lives at a framework-managed `default` path (outside cwd), the
-// updater will keep seeing `{}` even after a previous write succeeded.
-// For that case, prefer the partial-values form of `updateConfig` — the
-// provider itself merges the partial into the existing file on disk.
+// The updater-function form of `updateConfig` reads the current config
+// from the on-disk file before invoking the callback. On the first run
+// this means the updater sees an empty object (no file exists yet); on
+// subsequent runs it sees the previously persisted state — even when the
+// file lives at a framework-managed `default` path outside cwd.
 const tempDir = mkdtempSync(join(tmpdir(), 'fresh-updater-'));
 const configPath = join(tempDir, 'counter.json');
 
@@ -26,22 +20,26 @@ const app = cli('counter', {
         default: () => configPath,
       }),
   handler: async () => {
-    // Updater form on a fresh file — `current` is {}, so starting values
-    // must come from fallbacks in the user code.
+    // First call — no file exists. The updater gets `{}` as current, so
+    // `config.count` is undefined and we fall back to 0.
     await app.updateConfig((config) => {
       const existing = (config as { count?: number }).count ?? 0;
       config.count = existing + 1;
     });
 
     const first = JSON.parse(readFileSync(configPath, 'utf-8'));
-    console.log(`after updater form count: ${first.count}`);
+    console.log(`first call count: ${first.count}`);
 
-    // Partial-values form — the provider reads the on-disk file and merges,
-    // so this correctly bumps the count from 1 to 2 regardless of cwd.
-    await app.updateConfig({ count: first.count + 1 });
+    // Second call — the file now exists at the default path and the
+    // updater sees the previously persisted value, so this correctly
+    // increments from 1 to 2 without needing any manual plumbing.
+    await app.updateConfig((config) => {
+      const existing = (config as { count?: number }).count ?? 0;
+      config.count = existing + 1;
+    });
 
     const second = JSON.parse(readFileSync(configPath, 'utf-8'));
-    console.log(`after partial form count: ${second.count}`);
+    console.log(`second call count: ${second.count}`);
   },
 });
 

--- a/examples/config-patterns/fresh-updater.ts
+++ b/examples/config-patterns/fresh-updater.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// The updater-function form of updateConfig sees an empty object as the
+// "current" config when the default-path file does not exist yet. Use this
+// pattern when you need to read-modify-write but don't know whether the
+// config already exists.
+//
+// NOTE: the `current` value passed to the updater is derived from whatever
+// providers resolve from the current working directory. When the only file
+// on disk lives at a framework-managed `default` path (outside cwd), the
+// updater will keep seeing `{}` even after a previous write succeeded.
+// For that case, prefer the partial-values form of `updateConfig` — the
+// provider itself merges the partial into the existing file on disk.
+const tempDir = mkdtempSync(join(tmpdir(), 'fresh-updater-'));
+const configPath = join(tempDir, 'counter.json');
+
+const app = cli('counter', {
+  builder: (args) =>
+    args
+      .option('count', { type: 'number', default: 0 })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'counter.json',
+        default: () => configPath,
+      }),
+  handler: async () => {
+    // Updater form on a fresh file — `current` is {}, so starting values
+    // must come from fallbacks in the user code.
+    await app.updateConfig((config) => {
+      const existing = (config as { count?: number }).count ?? 0;
+      config.count = existing + 1;
+    });
+
+    const first = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after updater form count: ${first.count}`);
+
+    // Partial-values form — the provider reads the on-disk file and merges,
+    // so this correctly bumps the count from 1 to 2 regardless of cwd.
+    await app.updateConfig({ count: first.count + 1 });
+
+    const second = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after partial form count: ${second.count}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/hybrid-tool.ts
+++ b/examples/config-patterns/hybrid-tool.ts
@@ -1,0 +1,25 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// #region hybrid
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      // Project config — checked first
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+      })
+      // User config — fallback, with a default for init
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.json',
+        default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
+      }),
+  handler: (args) => {
+    console.log(`theme: ${args.theme}`);
+  },
+});
+
+(async () => await app.forge())();
+// #endregion hybrid

--- a/examples/config-patterns/init-flow.ts
+++ b/examples/config-patterns/init-flow.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// Simulate a fresh project directory with no config file on disk.
+const tempDir = mkdtempSync(join(tmpdir(), 'init-flow-'));
+const configPath = join(tempDir, 'my-tool.config.json');
+
+// #region init-flow
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => configPath,
+      }),
+  handler: () => undefined,
+}).command('init', {
+  description: 'Create a fresh config file and then update a value in place',
+  handler: async () => {
+    // First write: no file exists, so the framework falls through to the
+    // `default` path and creates the file.
+    console.log(`before init: exists=${existsSync(configPath)}`);
+    await app.updateConfig({ theme: 'dark', lang: 'fr' });
+
+    const afterInit = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after init: theme=${afterInit.theme} lang=${afterInit.lang}`);
+
+    // Second write: the file now resolves on disk, so the update is merged
+    // into the resolved file rather than going through the default path.
+    // Only `theme` is passed so `lang` is preserved.
+    await app.updateConfig({ theme: 'system' });
+
+    const afterUpdate = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(
+      `after update: theme=${afterUpdate.theme} lang=${afterUpdate.lang}`
+    );
+  },
+});
+// #endregion init-flow
+
+(async () => {
+  try {
+    await app.forge(['init']);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/init-flow.ts
+++ b/examples/config-patterns/init-flow.ts
@@ -19,19 +19,21 @@ const app = cli('my-tool', {
       }),
   handler: () => undefined,
 }).command('init', {
-  description: 'Create a fresh config file and then update a value in place',
+  description:
+    'Bootstrap a fresh config file and then update a value in place',
   handler: async () => {
-    // First write: no file exists, so the framework falls through to the
-    // `default` path and creates the file.
+    // First write: no file exists on disk, so the framework falls through
+    // to the `default` path and creates the file.
     console.log(`before init: exists=${existsSync(configPath)}`);
     await app.updateConfig({ theme: 'dark', lang: 'fr' });
 
     const afterInit = JSON.parse(readFileSync(configPath, 'utf-8'));
     console.log(`after init: theme=${afterInit.theme} lang=${afterInit.lang}`);
 
-    // Second write: the file now resolves on disk, so the update is merged
-    // into the resolved file rather than going through the default path.
-    // Only `theme` is passed so `lang` is preserved.
+    // Second write: the file now exists at the default path. The JSON
+    // file loader reads the existing content from that path, merges the
+    // partial update in, and writes it back — so `lang` is preserved
+    // without having to pass it through the update.
     await app.updateConfig({ theme: 'system' });
 
     const afterUpdate = JSON.parse(readFileSync(configPath, 'utf-8'));

--- a/examples/config-patterns/meta.yml
+++ b/examples/config-patterns/meta.yml
@@ -1,0 +1,37 @@
+id: config-patterns
+title: Configuration Patterns
+hidden: true
+description: |
+  Demonstrates various configuration patterns: project-root defaults,
+  user-level config, hybrid config, updateConfig usage, and custom providers.
+test:
+  - name: 'Project tool uses defaults when no config file exists'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json project-tool.ts'
+    assertions:
+      stdout:
+        contains: 'host: localhost'
+  - name: 'User tool uses defaults when no config file exists'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json user-tool.ts'
+    assertions:
+      stdout:
+        contains: 'theme: light'
+  - name: 'Hybrid tool uses defaults when no config file exists'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json hybrid-tool.ts'
+    assertions:
+      stdout:
+        contains: 'theme: light'
+  - name: 'updateConfig writes and reads back values'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json update-usage.ts'
+    assertions:
+      stdout:
+        contains: 'theme: light'
+  - name: 'Custom key-value provider loads config'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json custom-provider.ts'
+    assertions:
+      stdout:
+        contains: 'howdy, partner!'

--- a/examples/config-patterns/meta.yml
+++ b/examples/config-patterns/meta.yml
@@ -35,3 +35,69 @@ test:
     assertions:
       stdout:
         contains: 'howdy, partner!'
+  - name: 'init flow: first write creates file at default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'before init: exists=false'
+  - name: 'init flow: first write writes dark/fr'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'after init: theme=dark lang=fr'
+  - name: 'init flow: second write preserves lang and updates theme'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'after update: theme=system lang=fr'
+  - name: 'nested-default: default path file does not exist before write'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'before: exists=false'
+  - name: 'nested-default: framework creates intermediate directories and writes file'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'after: exists=true'
+  - name: 'nested-default: written file contains the updated value'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'written theme: dark'
+  - name: 'fresh-updater: updater form writes initial value to default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
+    assertions:
+      stdout:
+        contains: 'after updater form count: 1'
+  - name: 'fresh-updater: partial form merges with on-disk file'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
+    assertions:
+      stdout:
+        contains: 'after partial form count: 2'
+  - name: 'multi-provider-fallback: fallback provider default path is used when nothing resolves'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'before: user exists=false'
+  - name: 'multi-provider-fallback: fallback provider writes to its default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'after: user exists=true'
+  - name: 'multi-provider-fallback: written file has the updated theme'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'user config theme: dark'

--- a/examples/config-patterns/meta.yml
+++ b/examples/config-patterns/meta.yml
@@ -71,18 +71,18 @@ test:
     assertions:
       stdout:
         contains: 'written theme: dark'
-  - name: 'fresh-updater: updater form writes initial value to default path'
+  - name: 'fresh-updater: first call writes initial value via default path'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
     assertions:
       stdout:
-        contains: 'after updater form count: 1'
-  - name: 'fresh-updater: partial form merges with on-disk file'
+        contains: 'first call count: 1'
+  - name: 'fresh-updater: second call reads previously persisted value from default path'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
     assertions:
       stdout:
-        contains: 'after partial form count: 2'
+        contains: 'second call count: 2'
   - name: 'multi-provider-fallback: fallback provider default path is used when nothing resolves'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'

--- a/examples/config-patterns/multi-provider-fallback.ts
+++ b/examples/config-patterns/multi-provider-fallback.ts
@@ -1,0 +1,41 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// Demonstrates multi-provider fallback: a project config provider is
+// preferred but has no file on disk, so the user-level fallback provider's
+// `default` path is used for writes instead.
+const tempDir = mkdtempSync(join(tmpdir(), 'multi-provider-fallback-'));
+const userConfigPath = join(tempDir, '.config', 'my-tool', 'config.json');
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      // Project-level — preferred, but not present on disk in this example.
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+      })
+      // User-level fallback — has a default path so init-style writes work.
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.json',
+        default: () => userConfigPath,
+      }),
+  handler: async () => {
+    console.log(`before: user exists=${existsSync(userConfigPath)}`);
+    await app.updateConfig({ theme: 'dark' });
+
+    console.log(`after: user exists=${existsSync(userConfigPath)}`);
+    const written = JSON.parse(readFileSync(userConfigPath, 'utf-8'));
+    console.log(`user config theme: ${written.theme}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/nested-default.ts
+++ b/examples/config-patterns/nested-default.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// A "user-level" default that lives several directories deep — the framework
+// must create the intermediate folders (like `mkdir -p`) before writing.
+const baseDir = mkdtempSync(join(tmpdir(), 'nested-default-'));
+const configPath = join(baseDir, '.config', 'my-tool', 'settings.json');
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'settings.json',
+        default: () => configPath,
+      }),
+  handler: async () => {
+    console.log(`before: exists=${existsSync(configPath)}`);
+    await app.updateConfig({ theme: 'dark' });
+
+    console.log(`after: exists=${existsSync(configPath)}`);
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`written theme: ${written.theme}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/nested-default.ts
+++ b/examples/config-patterns/nested-default.ts
@@ -1,10 +1,16 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { ConfigurationFiles, cli } from 'cli-forge';
+import { ConfigurationProviders, cli } from 'cli-forge';
 
 // A "user-level" default that lives several directories deep — the framework
 // must create the intermediate folders (like `mkdir -p`) before writing.
+//
+// This example uses the `.config(provider, { default })` overload with the
+// convenience `ConfigurationProviders.JsonFile` factory. The class-based
+// `.config(ConfigurationFiles.JsonFileConfigLoader, { filename, default })`
+// form also works, but the factory style is shorter when you don't need a
+// custom transform.
 const baseDir = mkdtempSync(join(tmpdir(), 'nested-default-'));
 const configPath = join(baseDir, '.config', 'my-tool', 'settings.json');
 
@@ -12,8 +18,7 @@ const app = cli('my-tool', {
   builder: (args) =>
     args
       .option('theme', { type: 'string', default: 'light' })
-      .config(ConfigurationFiles.JsonFileConfigLoader, {
-        filename: 'settings.json',
+      .config(ConfigurationProviders.JsonFile('settings.json'), {
         default: () => configPath,
       }),
   handler: async () => {

--- a/examples/config-patterns/project-tool.ts
+++ b/examples/config-patterns/project-tool.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// #region find-project-root
+function findProjectRoot(from = process.cwd()): string {
+  let dir = from;
+  while (true) {
+    if (
+      existsSync(join(dir, 'package.json')) ||
+      existsSync(join(dir, '.git'))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return from; // reached filesystem root, fall back to cwd
+    dir = parent;
+  }
+}
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('host', { type: 'string', default: 'localhost' })
+      .option('port', { type: 'number', default: 3000 })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => join(findProjectRoot(), 'my-tool.config.json'),
+      }),
+  handler: (args) => {
+    console.log(`host: ${args.host}`);
+    console.log(`port: ${args.port}`);
+  },
+});
+
+(async () => await app.forge())();
+// #endregion find-project-root

--- a/examples/config-patterns/update-usage.ts
+++ b/examples/config-patterns/update-usage.ts
@@ -1,0 +1,39 @@
+import { join } from 'path';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+const tempDir = mkdtempSync(join(tmpdir(), 'update-usage-'));
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => join(tempDir, 'my-tool.config.json'),
+      }),
+  // #region update-config
+  handler: async (args) => {
+    // Partial update — only the specified keys change
+    await app.updateConfig({ theme: 'dark' });
+
+    // Updater function — read-modify-write
+    await app.updateConfig((config) => {
+      config.lang = config.lang === 'en' ? 'fr' : 'en';
+    });
+
+    console.log(`theme: ${args.theme}`);
+    console.log(`lang: ${args.lang}`);
+  },
+  // #endregion update-config
+});
+
+(async () => {
+  try {
+    await app.forge();
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/user-tool.ts
+++ b/examples/config-patterns/user-tool.ts
@@ -1,0 +1,22 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// #region user-level
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.json',
+        default: () => join(homedir(), '.config', 'my-tool', 'config.json'),
+      }),
+  handler: (args) => {
+    console.log(`theme: ${args.theme}`);
+    console.log(`lang: ${args.lang}`);
+  },
+});
+
+(async () => await app.forge())();
+// #endregion user-level

--- a/examples/configuration-files/configured-cli.ts
+++ b/examples/configuration-files/configured-cli.ts
@@ -9,16 +9,22 @@ import { ConfigurationProviders, cli } from 'cli-forge';
         .option('greeting', { type: 'string' })
         .option('farewell', { type: 'string' })
 
+        // #region package-json-config
         // Allows loading configuration values from the 'configured-cli' entry in package.json.
         .config(ConfigurationProviders.PackageJson('configured-cli'))
+        // #endregion package-json-config
 
+        // #region json-file-config
         // Allows loading configuration values from the root of 'configured-cli.config.json'.
         .config(ConfigurationProviders.JsonFile('configured-cli.config.json'))
+        // #endregion json-file-config
 
+        // #region nested-key-config
         // Allows loading configuration values from the 'configured-cli' entry in 'other.config.json'.
         .config(
           ConfigurationProviders.JsonFile('other.config.json', 'configured-cli')
         ),
+        // #endregion nested-key-config
 
     handler: (args) => {
       console.log(`${args.greeting}, ${args.name}!`);

--- a/examples/default-config/cli.ts
+++ b/examples/default-config/cli.ts
@@ -1,0 +1,46 @@
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// #region init-command
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      // The `default` option tells the framework where to create the config file
+      // when no existing config is found on disk.
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => join(process.cwd(), 'my-tool.config.json'),
+      }),
+
+  handler: (args) => {
+    console.log(`theme: ${args.theme}`);
+    console.log(`lang: ${args.lang}`);
+  },
+});
+
+app
+  .command('init', {
+    description: 'Initialize configuration file with current settings',
+    handler: async (args) => {
+      await app.updateConfig({ theme: args.theme, lang: args.lang });
+      console.log('Config written to my-tool.config.json');
+    },
+  })
+  .command('set', {
+    builder: (cmd) =>
+      cmd
+        .option('key', { type: 'string', required: true })
+        .option('value', { type: 'string', required: true }),
+    description: 'Update a single config value',
+    handler: async (args) => {
+      await app.updateConfig({
+        [args.key]: args.value,
+      } as Partial<{ theme: string; lang: string }>);
+      console.log(`Set ${args.key} = ${args.value}`);
+    },
+  });
+
+(async () => await app.forge())();
+// #endregion init-command

--- a/examples/default-config/cli.ts
+++ b/examples/default-config/cli.ts
@@ -8,7 +8,9 @@ const app = cli('my-tool', {
       .option('theme', { type: 'string', default: 'light' })
       .option('lang', { type: 'string', default: 'en' })
       // The `default` option tells the framework where to create the config file
-      // when no existing config is found on disk.
+      // when no existing config is found on disk. A real project tool would walk
+      // up to the project root (e.g., nearest package.json or .git) instead of
+      // using cwd directly.
       .config(ConfigurationFiles.JsonFileConfigLoader, {
         filename: 'my-tool.config.json',
         default: () => join(process.cwd(), 'my-tool.config.json'),

--- a/examples/default-config/init-test.ts
+++ b/examples/default-config/init-test.ts
@@ -1,0 +1,33 @@
+import { join } from 'path';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// Create a temp directory to simulate a fresh project with no config file
+const tempDir = mkdtempSync(join(tmpdir(), 'default-config-'));
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => join(tempDir, 'my-tool.config.json'),
+      }),
+  handler: async () => {
+    // Write config with defaults — file doesn't exist yet
+    await app.updateConfig({ theme: 'dark', lang: 'fr' });
+
+    // Read back the created file
+    const configPath = join(tempDir, 'my-tool.config.json');
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`theme: ${written.theme}`);
+    console.log(`lang: ${written.lang}`);
+
+    // Clean up
+    rmSync(tempDir, { recursive: true });
+  },
+});
+
+(async () => await app.forge())();

--- a/examples/default-config/meta.yml
+++ b/examples/default-config/meta.yml
@@ -1,0 +1,20 @@
+id: default-config
+title: Default Config Path
+hidden: true
+description: |
+  Demonstrates the `default` option on configuration providers. When no config
+  file exists on disk, `updateConfig` uses the default path to create one.
+  This enables `init` commands that bootstrap configuration from scratch.
+test:
+  - name: 'Creates config file at default path when none exists'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-test.ts'
+    assertions:
+      stdout:
+        contains: 'theme: dark'
+  - name: 'Written config contains all updated values'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-test.ts'
+    assertions:
+      stdout:
+        contains: 'lang: fr'

--- a/packages/cli-forge/src/index.ts
+++ b/packages/cli-forge/src/index.ts
@@ -17,6 +17,7 @@ export type {
 } from './lib/completion-types';
 export { completionHelpers } from './lib/completion-types';
 export { ConfigurationProviders } from './lib/configuration-providers';
+export { ConfigurationFiles } from '@cli-forge/parser';
 export type { LocalizationDictionary, LocalizationFunction } from '@cli-forge/parser';
 export type { ProviderConfig, GlobalProviderConfig } from './lib/public-api';
 export type {

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -512,6 +512,58 @@ describe('cliForge', () => {
     });
   });
 
+  describe('repeated forge() calls on the same instance', () => {
+    it('resets commandChain between forge() calls so a CLI instance can run multiple commands', async () => {
+      const calls: string[] = [];
+      const app = cli('app')
+        .command('init', {
+          handler: () => {
+            calls.push('init');
+          },
+        })
+        .command('run', {
+          handler: () => {
+            calls.push('run');
+          },
+        });
+
+      await app.forge(['init']);
+      await app.forge(['run']);
+      await app.forge(['init']);
+
+      expect(calls).toEqual(['init', 'run', 'init']);
+    });
+
+    it('resets commandChain even after a prior forge() call threw', async () => {
+      const { restore } = mockConsoleLog();
+      const originalError = console.error;
+      console.error = () => undefined;
+      try {
+        const calls: string[] = [];
+        const app = cli('app')
+          .command('run', {
+            handler: () => {
+              calls.push('run');
+              throw new Error('boom');
+            },
+          })
+          .command('ok', {
+            handler: () => {
+              calls.push('ok');
+            },
+          });
+
+        await expect(app.forge(['run'])).rejects.toThrow();
+        // Second call must not walk a stale chain from the first one.
+        await app.forge(['ok']);
+        expect(calls).toEqual(['run', 'ok']);
+      } finally {
+        console.error = originalError;
+        restore();
+      }
+    });
+  });
+
   it('should support subcommands with positional args', async () => {
     const args = await cli('test')
       .command(

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -9,7 +9,7 @@ import {
   setFileSystemProvider,
 } from '@cli-forge/parser';
 import { InternalCLI } from './internal-cli';
-import { cli } from './public-api';
+import { cli, HandlerExecutionError } from './public-api';
 import type { PromptProvider } from './prompt-types';
 
 const ORIGINAL_CONSOLE_LOG = console.log;
@@ -361,14 +361,20 @@ describe('cliForge', () => {
 
   it('should print help if command throws', async () => {
     const { getOutput } = mockConsoleLog();
-    await cli('test')
-      .command('foo', {
-        builder: (argv) => argv.option('bar', { type: 'string' }),
-        handler: () => {
-          throw new Error('test');
-        },
-      })
-      .forge(['foo']);
+    // Handler errors now propagate through the registered error handler
+    // chain (matching init hook / parse error behavior) and re-throw after
+    // all handlers run, so callers can observe the failure. The default
+    // catch-all handler still prints the help text and sets exitCode=1.
+    await expect(
+      cli('test')
+        .command('foo', {
+          builder: (argv) => argv.option('bar', { type: 'string' }),
+          handler: () => {
+            throw new Error('test');
+          },
+        })
+        .forge(['foo'])
+    ).rejects.toThrow(/Error executing handler for "test foo"/);
     expect(getOutput()).toMatchInlineSnapshot(`
       "Usage: test foo
 
@@ -378,6 +384,132 @@ describe('cliForge', () => {
         --bar     "
     `);
     expect(process.exitCode).toBe(1);
+  });
+
+  describe('handler error propagation', () => {
+    const swallowStderr = () => {
+      const original = console.error;
+      console.error = () => undefined;
+      return () => {
+        console.error = original;
+      };
+    };
+
+    it('wraps handler errors in HandlerExecutionError with the original as cause', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      const original = new Error('underlying failure');
+      try {
+        await cli('app')
+          .command('run', {
+            handler: () => {
+              throw original;
+            },
+          })
+          .forge(['run']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HandlerExecutionError);
+        expect((e as HandlerExecutionError).command).toBe('app run');
+        expect((e as HandlerExecutionError).cause).toBe(original);
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('routes handler errors through custom errorHandler before re-throwing', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      let seen: unknown;
+      try {
+        await cli('app')
+          .errorHandler((e) => {
+            seen = e;
+          })
+          .command('run', {
+            handler: () => {
+              throw new Error('kaboom');
+            },
+          })
+          .forge(['run']);
+      } catch {
+        // withErrorHandlers re-throws after handlers run
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+      expect(seen).toBeInstanceOf(HandlerExecutionError);
+      expect(((seen as HandlerExecutionError).cause as Error).message).toBe(
+        'kaboom'
+      );
+    });
+
+    it('preserves async handler rejections', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('run', {
+            handler: async () => {
+              await Promise.resolve();
+              throw new Error('async kaboom');
+            },
+          })
+          .forge(['run']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HandlerExecutionError);
+        expect(((e as HandlerExecutionError).cause as Error).message).toBe(
+          'async kaboom'
+        );
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('reports the full subcommand path on nested handler failures', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('build', {
+            builder: (cmd) =>
+              cmd.command('release', {
+                handler: () => {
+                  throw new Error('release failed');
+                },
+              }),
+            handler: () => undefined,
+          })
+          .forge(['build', 'release']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect((e as HandlerExecutionError).command).toBe('app build release');
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('does not wrap framework "missing command" diagnostics', async () => {
+      // demandCommand is a user-facing prompt ("you forgot to specify a
+      // command"), not a handler failure. It should still resolve
+      // gracefully (print help + exitCode) rather than rejecting.
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('run', { handler: () => undefined })
+          .demandCommand()
+          .forge([]);
+        expect(process.exitCode).toBe(1);
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
   });
 
   it('should support subcommands with positional args', async () => {

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -1,4 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ConfigurationFiles,
+  MemoryEnvironmentProvider,
+  MemoryFileSystemProvider,
+  getEnvironmentProvider,
+  getFileSystemProvider,
+  setEnvironmentProvider,
+  setFileSystemProvider,
+} from '@cli-forge/parser';
 import { InternalCLI } from './internal-cli';
 import { cli } from './public-api';
 import type { PromptProvider } from './prompt-types';
@@ -1956,6 +1965,184 @@ describe('cliForge', () => {
       expect(handlerArgs.name).toBe('prompted-name');
       expect(handlerArgs.port).toBe(42);
       expect(handlerArgs.verbose).toBe(false); // default, not prompted
+    });
+  });
+
+  describe('updateConfig', () => {
+    let originalEnv: ReturnType<typeof getEnvironmentProvider>;
+    let originalFs: ReturnType<typeof getFileSystemProvider>;
+    let fs: MemoryFileSystemProvider;
+
+    beforeEach(() => {
+      originalEnv = getEnvironmentProvider();
+      originalFs = getFileSystemProvider();
+      fs = new MemoryFileSystemProvider();
+      setEnvironmentProvider(
+        new MemoryEnvironmentProvider({ cwd: '/root' })
+      );
+      setFileSystemProvider(fs);
+    });
+
+    afterEach(() => {
+      setEnvironmentProvider(originalEnv);
+      setFileSystemProvider(originalFs);
+    });
+
+    // These tests exercise the `app.updateConfig()` flow the way real users
+    // call it: from inside a command handler, after `forge()` has run the
+    // root builder (which is where config providers get registered).
+
+    it('updates an existing config file resolved from cwd', async () => {
+      fs.writeFileSync(
+        '/root/app.config.json',
+        JSON.stringify({ theme: 'light', lang: 'en' })
+      );
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+        },
+      });
+
+      await app.forge([]);
+
+      const written = JSON.parse(fs.readFileSync('/root/app.config.json'));
+      expect(written).toEqual({ theme: 'dark', lang: 'fr' });
+    });
+
+    it('writes to the default path when no config file exists on disk', async () => {
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(fs.existsSync('/root/app.config.json')).toBe(true);
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        theme: 'dark',
+        lang: 'fr',
+      });
+    });
+
+    it('supports `default` as a lazy function', async () => {
+      let invocations = 0;
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: () => {
+                invocations++;
+                return '/home/user/.config/app/config.json';
+              },
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(invocations).toBe(1);
+      expect(
+        fs.existsSync('/home/user/.config/app/config.json')
+      ).toBe(true);
+    });
+
+    it('falls back to default on first write, then writes back to the resolved file on subsequent updates', async () => {
+      // Two updateConfig calls from the same handler. The first creates the
+      // file at the `default` path; the second should go to the freshly
+      // resolved path rather than re-using targetPath, and must merge with
+      // the existing file contents instead of overwriting them.
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+          await app.updateConfig({ theme: 'system' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        theme: 'system',
+        lang: 'fr',
+      });
+    });
+
+    it('supports updater functions with proxy tracking on a fresh default path', async () => {
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('count', { type: 'number', default: 0 })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig((config) => {
+            const prev = (config as { count?: number }).count ?? 0;
+            config.count = prev + 5;
+          });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        count: 5,
+      });
+    });
+
+    it('errors clearly when no provider resolves and no default is configured', async () => {
+      // `runCommand` catches handler errors and logs via console.error to
+      // surface them nicely to end users, so we capture the rejection from
+      // inside the handler instead of asserting on `forge()`'s return.
+      let captured: unknown;
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+            }),
+        handler: async () => {
+          try {
+            await app.updateConfig({ theme: 'dark' });
+          } catch (e) {
+            captured = e;
+          }
+        },
+      });
+
+      await app.forge([]);
+
+      expect(captured).toBeInstanceOf(Error);
+      expect((captured as Error).message).toMatch(/no provider resolved/);
     });
   });
 });

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -1191,7 +1191,6 @@ export class InternalCLI<
     }
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   }
-  }
 
   async updateConfig(values: Partial<TArgs>): Promise<void>;
   async updateConfig(
@@ -1225,6 +1224,15 @@ export class InternalCLI<
     this.withErrorHandlers(async () => {
       let argv: TArgs & { help?: boolean; version?: boolean };
       let validationFailedError: ValidationFailedError<TArgs> | undefined;
+
+      // `commandChain` is mutated during the discovery loop (subcommand
+      // names are pushed as they are matched). Clear it at the start of
+      // every forge() call so a CLI instance can be invoked multiple
+      // times — e.g. in a long-running server or a test that exercises
+      // several command paths — without walking a stale chain on the
+      // second call. Other per-call state (unmatched tokens, parsed
+      // argv) is already local to this closure.
+      this.commandChain = [];
 
       // Run root builder (may register options, init hooks, commands).
       // If the builder came from a $0 alias, skip it here — we defer

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -1124,11 +1124,40 @@ export class InternalCLI<
 
   config(
     provider: ConfigurationFiles.AnyConfigProvider<TArgs>
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  config<
+    C extends new (
+      opts: any
+    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+  >(
+    ctor: C,
+    options: ConstructorParameters<C>[0] & {
+      default?: ConfigurationFiles.DefaultConfig<
+        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+      >;
+    }
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  config<
+    C extends new (
+      opts: any
+    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+  >(
+    providerOrCtor: ConfigurationFiles.AnyConfigProvider<TArgs> | C,
+    options?: ConstructorParameters<C>[0] & {
+      default?: ConfigurationFiles.DefaultConfig<
+        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+      >;
+    }
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
-    this.parser.config(
-      provider as ConfigurationFiles.AnyConfigProvider<any>
-    );
+    if (options !== undefined) {
+      this.parser.config(providerOrCtor as any, options);
+    } else {
+      this.parser.config(
+        providerOrCtor as ConfigurationFiles.AnyConfigProvider<any>
+      );
+    }
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  }
   }
 
   async updateConfig(values: Partial<TArgs>): Promise<void>;

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -36,6 +36,7 @@ import {
   CLIHandlerContext,
   Command,
   ErrorHandler,
+  HandlerExecutionError,
   SDKCommand,
 } from './public-api';
 import type {
@@ -160,48 +161,58 @@ export class InternalCLI<
 
   private _versionOverride?: string;
 
+  // Default error handler chain. User-registered handlers are prepended via
+  // `errorHandler()` and run first, so these act as fallbacks. Handlers that
+  // don't match the error type should re-throw to pass the error to the next
+  // handler in the chain.
   private registeredErrorHandlers: Array<ErrorHandler> = [
+    // Specific: print parse/validation failures using the familiar format.
     (e: unknown, actions) => {
-      if (e instanceof ValidationFailedError) {
-        this.printHelp();
-        console.log();
-        console.log(e.message);
+      if (!(e instanceof ValidationFailedError)) throw e;
+      this.printHelp();
+      console.log();
+      console.log(e.message);
 
-        let currentCommand: InternalCLI<any, any, any, any> = this;
-        for (const cmd of this.commandChain) {
-          const next = currentCommand.registeredCommands[cmd];
-          if (!next) break;
-          currentCommand = next;
-        }
-        const subcommandNames = Object.keys(
-          currentCommand.registeredCommands
-        ).filter((name) => name !== '$0');
-
-        for (const err of e.errors) {
-          console.log(`  - ${err.message}`);
-          if (err instanceof UnknownOptionError) {
-            const suggestion = err.suggestedOptions[0];
-            if (suggestion) {
-              console.log(`    (did you mean '${suggestion}'?)`);
-            }
-            continue;
-          }
-          if (
-            err instanceof UnknownArgumentError &&
-            subcommandNames.length > 0 &&
-            !err.input.startsWith('-')
-          ) {
-            const suggestion = calculateSuggestedString(
-              err.input,
-              subcommandNames
-            );
-            if (suggestion) {
-              console.log(`    (did you mean '${suggestion}'?)`);
-            }
-          }
-        }
-        actions.exit(1);
+      let currentCommand: InternalCLI<any, any, any, any> = this;
+      for (const cmd of this.commandChain) {
+        const next = currentCommand.registeredCommands[cmd];
+        if (!next) break;
+        currentCommand = next;
       }
+      const subcommandNames = Object.keys(
+        currentCommand.registeredCommands
+      ).filter((name) => name !== '$0');
+
+      for (const err of e.errors) {
+        console.log(`  - ${err.message}`);
+        if (err instanceof UnknownOptionError) {
+          const suggestion = err.suggestedOptions[0];
+          if (suggestion) {
+            console.log(`    (did you mean '${suggestion}'?)`);
+          }
+          continue;
+        }
+        if (
+          err instanceof UnknownArgumentError &&
+          subcommandNames.length > 0 &&
+          !err.input.startsWith('-')
+        ) {
+          const suggestion = calculateSuggestedString(
+            err.input,
+            subcommandNames
+          );
+          if (suggestion) {
+            console.log(`    (did you mean '${suggestion}'?)`);
+          }
+        }
+      }
+      actions.exit(1);
+    },
+    (e: unknown, actions) => {
+      if (typeof process !== 'undefined') process.exitCode = 1;
+      console.error(e);
+      this.printHelp();
+      actions.exit(1);
     },
   ];
 
@@ -717,33 +728,74 @@ export class InternalCLI<
         middlewares.add(mw);
       }
     }
-    try {
-      if (cmd.requiresCommand) {
-        throw new Error(
+    // "Missing command" is a user-facing prompt (the CLI was invoked
+    // without a command to run), not a programmer error. Print help and
+    // set exitCode rather than propagating through the error-handler
+    // chain, so interactive use and `demandCommand()` stay ergonomic.
+    if (cmd.requiresCommand) {
+      if (typeof process !== 'undefined') process.exitCode = 1;
+      console.error(
+        new Error(
           `${[this.name, ...this.commandChain].join(' ')} requires a command`
-        );
-      }
-      if (cmd.configuration?.handler) {
-        for (const middleware of middlewares) {
-          if (executedMiddleware?.has(middleware)) continue;
-          const middlewareResult = await middleware(args as any);
-          if (
-            middlewareResult !== void 0 &&
-            typeof middlewareResult === 'object'
-          ) {
-            args = middlewareResult as T;
-          }
+        )
+      );
+      this.printHelp();
+      return args;
+    }
+    if (cmd.configuration?.handler) {
+      for (const middleware of middlewares) {
+        if (executedMiddleware?.has(middleware)) continue;
+        const middlewareResult = await middleware(args as any);
+        if (
+          middlewareResult !== void 0 &&
+          typeof middlewareResult === 'object'
+        ) {
+          args = middlewareResult as T;
         }
+<<<<<<< HEAD
         // Keep ALS context args in sync after middleware transformations
         const store = contextStorage.getStore();
         if (store) {
           store.args = args as Record<string, unknown>;
         }
+=======
+      }
+      // Errors thrown from the handler are wrapped in a HandlerExecutionError
+      // so custom error handlers (registered via `.errorHandler()`) can
+      // distinguish them from framework errors. The original error is
+      // preserved on `.cause`. The wrapped error propagates up through
+      // `withErrorHandlers`, which runs the registered handler chain and
+      // then re-throws — matching init hook and parse error behavior.
+      try {
+>>>>>>> abe2234 (fix(cli-forge): route handler errors through the error-handler chain)
         await cmd.configuration.handler(args, {
           command: cmd as any,
         });
-        return args;
+      } catch (cause) {
+        throw new HandlerExecutionError(
+          [this.name, ...this.commandChain].join(' '),
+          { cause }
+        );
+      }
+      return args;
+    }
+
+    // We can treat a command as a subshell if it has subcommands
+    if (Object.keys(cmd.registeredCommands).length > 0) {
+      if (typeof process === 'undefined' || !process.stdout?.isTTY) {
+        // If we're not in a TTY (or in a browser), we can't run an interactive shell...
+        // Maybe we should warn here?
+      } else if (args.unmatched.length > 0) {
+        // If there are unmatched args, we don't run an interactive shell...
+        // this could represent a user misspelling a subcommand so it gets rather confusing.
+        console.warn(
+          `Warning: Unrecognized command or arguments: ${args.unmatched.join(
+            ' '
+          )}`
+        );
+        cmd.printHelp();
       } else {
+<<<<<<< HEAD
         // We can treat a command as a subshell if it has subcommands
         if (Object.keys(cmd.registeredCommands).length > 0) {
           if (typeof process === 'undefined' || !process.stdout?.isTTY) {
@@ -775,22 +827,38 @@ export class InternalCLI<
                   })
                 );
               });
+=======
+        const shellMod = await getInteractiveShellModule();
+        if (!shellMod.INTERACTIVE_SHELL) {
+          const tui = new shellMod.InteractiveShell(
+            this as unknown as InternalCLI<any>,
+            {
+              prependArgs: originalArgV,
+>>>>>>> abe2234 (fix(cli-forge): route handler errors through the error-handler chain)
             }
-          }
-        }
-        // No subcommands so subshell doesn't make sense
-        // No handler, so nothing to run
-        else {
-          throw new Error(
-            `${[this.name, ...this.commandChain].join(' ')} is not implemented.`
           );
+          await new Promise<void>((res) => {
+            ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach((s) =>
+              process?.on(s, () => {
+                tui.close();
+                res();
+              })
+            );
+          });
         }
       }
-    } catch (e) {
-      if (typeof process !== 'undefined') process.exitCode = 1;
-      console.error(e);
-      this.printHelp();
+      return args;
     }
+
+    // No handler, no subcommands. Treated as a framework diagnostic, like
+    // `requiresCommand` — print help and set exitCode rather than throwing.
+    if (typeof process !== 'undefined') process.exitCode = 1;
+    console.error(
+      new Error(
+        `${[this.name, ...this.commandChain].join(' ')} is not implemented.`
+      )
+    );
+    this.printHelp();
     return args;
   }
 

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -1123,29 +1123,33 @@ export class InternalCLI<
   }
 
   config(
-    provider: ConfigurationFiles.AnyConfigProvider<TArgs>
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   config<
     C extends new (
       opts: any
-    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+    ) => ConfigurationFiles.ConfigProviderRegistration<TArgs>,
   >(
     ctor: C,
     options: ConstructorParameters<C>[0] & {
       default?: ConfigurationFiles.DefaultConfig<
-        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+        InstanceType<C> extends readonly (infer P)[]
+          ? ConfigurationFiles.ExtractLocation<P>
+          : ConfigurationFiles.ExtractLocation<InstanceType<C>>
       >;
     }
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   config<
     C extends new (
       opts: any
-    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+    ) => ConfigurationFiles.ConfigProviderRegistration<TArgs>,
   >(
-    providerOrCtor: ConfigurationFiles.AnyConfigProvider<TArgs> | C,
+    providerOrCtor: ConfigurationFiles.ConfigProviderRegistration<TArgs> | C,
     options?: ConstructorParameters<C>[0] & {
       default?: ConfigurationFiles.DefaultConfig<
-        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+        InstanceType<C> extends readonly (infer P)[]
+          ? ConfigurationFiles.ExtractLocation<P>
+          : ConfigurationFiles.ExtractLocation<InstanceType<C>>
       >;
     }
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders> {
@@ -1153,7 +1157,7 @@ export class InternalCLI<
       this.parser.config(providerOrCtor as any, options);
     } else {
       this.parser.config(
-        providerOrCtor as ConfigurationFiles.AnyConfigProvider<any>
+        providerOrCtor as ConfigurationFiles.ConfigProviderRegistration<any>
       );
     }
     return this as unknown as CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -752,22 +752,13 @@ export class InternalCLI<
         ) {
           args = middlewareResult as T;
         }
-<<<<<<< HEAD
         // Keep ALS context args in sync after middleware transformations
         const store = contextStorage.getStore();
         if (store) {
           store.args = args as Record<string, unknown>;
         }
-=======
       }
-      // Errors thrown from the handler are wrapped in a HandlerExecutionError
-      // so custom error handlers (registered via `.errorHandler()`) can
-      // distinguish them from framework errors. The original error is
-      // preserved on `.cause`. The wrapped error propagates up through
-      // `withErrorHandlers`, which runs the registered handler chain and
-      // then re-throws — matching init hook and parse error behavior.
       try {
->>>>>>> abe2234 (fix(cli-forge): route handler errors through the error-handler chain)
         await cmd.configuration.handler(args, {
           command: cmd as any,
         });
@@ -795,46 +786,12 @@ export class InternalCLI<
         );
         cmd.printHelp();
       } else {
-<<<<<<< HEAD
-        // We can treat a command as a subshell if it has subcommands
-        if (Object.keys(cmd.registeredCommands).length > 0) {
-          if (typeof process === 'undefined' || !process.stdout?.isTTY) {
-            // If we're not in a TTY (or in a browser), we can't run an interactive shell...
-            // Maybe we should warn here?
-          } else if (args.unmatched.length > 0) {
-            // If there are unmatched args, we don't run an interactive shell...
-            // this could represent a user misspelling a subcommand so it gets rather confusing.
-            console.warn(
-              `Warning: Unrecognized command or arguments: ${args.unmatched.join(
-                ' '
-              )}`
-            );
-            cmd.printHelp();
-          } else {
-            const shellMod = await getInteractiveShellModule();
-            if (!shellMod.INTERACTIVE_SHELL) {
-              const tui = new shellMod.InteractiveShell(
-                this as unknown as AnyInternalCLI,
-                {
-                  prependArgs: originalArgV,
-                }
-              );
-              await new Promise<void>((res) => {
-                ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach((s) =>
-                  process?.on(s, () => {
-                    tui.close();
-                    res();
-                  })
-                );
-              });
-=======
         const shellMod = await getInteractiveShellModule();
         if (!shellMod.INTERACTIVE_SHELL) {
           const tui = new shellMod.InteractiveShell(
-            this as unknown as InternalCLI<any>,
+            this as unknown as AnyInternalCLI,
             {
               prependArgs: originalArgV,
->>>>>>> abe2234 (fix(cli-forge): route handler errors through the error-handler chain)
             }
           );
           await new Promise<void>((res) => {
@@ -1192,6 +1149,10 @@ export class InternalCLI<
 
   config(
     provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+  config(
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>,
+    options: { default?: ConfigurationFiles.DefaultConfig<string | URL> }
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
   config<
     C extends new (

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -449,7 +449,7 @@ export interface CLI<
    * @param provider Provider to register.
    */
   config(
-    provider: ConfigurationFiles.AnyConfigProvider<TArgs>
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   /**
@@ -462,12 +462,14 @@ export interface CLI<
   config<
     C extends new (
       opts: any
-    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+    ) => ConfigurationFiles.ConfigProviderRegistration<TArgs>,
   >(
     ctor: C,
     options: ConstructorParameters<C>[0] & {
       default?: ConfigurationFiles.DefaultConfig<
-        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+        InstanceType<C> extends readonly (infer P)[]
+          ? ConfigurationFiles.ExtractLocation<P>
+          : ConfigurationFiles.ExtractLocation<InstanceType<C>>
       >;
     }
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -453,6 +453,26 @@ export interface CLI<
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   /**
+   * Registers a configuration provider by class and options.
+   * Framework options like `default` are extracted and stored as metadata.
+   *
+   * @param ctor The provider class constructor.
+   * @param options Constructor options merged with framework options (e.g., `default`).
+   */
+  config<
+    C extends new (
+      opts: any
+    ) => ConfigurationFiles.ConfigurationProvider<TArgs, any>,
+  >(
+    ctor: C,
+    options: ConstructorParameters<C>[0] & {
+      default?: ConfigurationFiles.DefaultConfig<
+        ConfigurationFiles.ExtractLocation<InstanceType<C>>
+      >;
+    }
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
+
+  /**
    * Updates configuration by routing each key to its owning provider.
    *
    * @param values Partial configuration to write.

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -453,6 +453,30 @@ export interface CLI<
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   /**
+   * Registers a pre-built configuration provider with framework-level
+   * metadata such as `default`. Useful with convenience factories like
+   * {@link ConfigurationProviders.JsonFile} that already return a
+   * fully-constructed provider but still need to carry a `default` path
+   * so `updateConfig` can create a config file when none exists.
+   *
+   * @example
+   * ```ts
+   * cli('my-tool')
+   *   .option('theme', { type: 'string' })
+   *   .config(ConfigurationProviders.JsonFile('my-tool.config.json'), {
+   *     default: () => join(process.cwd(), 'my-tool.config.json'),
+   *   });
+   * ```
+   *
+   * @param provider The configuration provider to register.
+   * @param options Framework-level options (e.g. `default`).
+   */
+  config(
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>,
+    options: { default?: ConfigurationFiles.DefaultConfig<string | URL> }
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent>;
+
+  /**
    * Registers a configuration provider by class and options.
    * Framework options like `default` are extracted and stored as metadata.
    *

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -1270,6 +1270,47 @@ export type ErrorHandler = (
 export type AnyCLI = CLI<any, any, any, any, any>;
 
 /**
+ * Error thrown when a command handler (or middleware running as part of the
+ * same execution phase) throws during `forge()`. The original error is
+ * preserved on the {@link cause} property so custom error handlers can
+ * inspect it, while still being able to distinguish framework-reported
+ * handler failures from other errors via `instanceof HandlerExecutionError`.
+ *
+ * @example
+ * ```ts
+ * cli('app', {
+ *   handler: async () => {
+ *     throw new Error('bad thing');
+ *   },
+ * })
+ *   .errorHandler((e) => {
+ *     if (e instanceof HandlerExecutionError) {
+ *       console.error('command:', e.command);
+ *       console.error('cause:', e.cause);
+ *     }
+ *   })
+ *   .forge();
+ * ```
+ */
+export class HandlerExecutionError extends Error {
+  override name = 'HandlerExecutionError';
+  /** The command path (e.g. `"my-tool build release"`) whose handler threw. */
+  readonly command: string;
+
+  constructor(command: string, options: { cause: unknown }) {
+    const causeMessage =
+      options.cause instanceof Error
+        ? options.cause.message
+        : String(options.cause);
+    super(
+      `Error executing handler for "${command}": ${causeMessage}`,
+      options as ErrorOptions
+    );
+    this.command = command;
+  }
+}
+
+/**
  * Base CLI constraint for generic functions. Uses `ParsedArgs` instead of `any`
  * for `TArgs` so that method return types (like `.option()`) compute correctly
  * through `chain()`. Use this as the bound in `<T extends UnknownCLI>`.

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -444,7 +444,7 @@ export interface CLI<
   ): CLI<TArgs, THandlerReturn, TChildren, TParent, TProviders>;
 
   /**
-   * Register's a configuration provider for the CLI. See {@link ConfigurationProviders} for built-in providers.
+   * Registers a configuration provider for the CLI. See {@link ConfigurationProviders} for built-in providers.
    *
    * @param provider Provider to register.
    */

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
@@ -138,6 +138,78 @@ describe('AggregateConfigProvider', () => {
       expect(result).toEqual({ foo: 'root', bar: 'base' });
     });
 
+    it('should prioritize explicit values over extends-derived values regardless of provider order', () => {
+      // Provider A (first) has extends that brings in "name" from a base config.
+      // Provider B (second) explicitly sets "name" in its own config.
+      // Provider B's explicit value should win over A's extends-derived value.
+      const providerA: ConfigurationProvider<any> = {
+        resolve: (dir) => {
+          if (dir === '/root') return '/root/.configA';
+          if (dir === '/base') return '/base/.configA';
+          return undefined;
+        },
+        load: (file) => {
+          if (file === '/root/.configA')
+            return { extends: '/base', color: 'red' };
+          if (file === '/base/.configA')
+            return { name: 'from-base', host: 'base-host' };
+          return {};
+        },
+      };
+      const providerB = makeMockProvider({
+        '/root/.configB': { name: 'B-explicit', port: 8080 },
+      });
+
+      const aggregate = new AggregateConfigProvider([providerA, providerB]);
+      const result = aggregate.load('/root');
+
+      // B's explicit "name" beats A's extends-derived "name"
+      expect(result.name).toBe('B-explicit');
+      // A's explicit "color" is kept
+      expect(result.color).toBe('red');
+      // B's explicit "port" is kept
+      expect(result.port).toBe(8080);
+      // A's extends-derived "host" fills in (no explicit value from anyone)
+      expect(result.host).toBe('base-host');
+    });
+
+    it('should prioritize extends-derived values by provider order when no explicit value exists', () => {
+      // Both providers have extends. When no explicit value exists for a key,
+      // the first provider's extends-derived value should win.
+      const providerA: ConfigurationProvider<any> = {
+        resolve: (dir) => {
+          if (dir === '/root') return '/root/.configA';
+          if (dir === '/baseA') return '/baseA/.config';
+          return undefined;
+        },
+        load: (file) => {
+          if (file === '/root/.configA')
+            return { extends: '/baseA', color: 'red' };
+          if (file === '/baseA/.config') return { theme: 'dark' };
+          return {};
+        },
+      };
+      const providerB: ConfigurationProvider<any> = {
+        resolve: (dir) => {
+          if (dir === '/root') return '/root/.configB';
+          if (dir === '/baseB') return '/baseB/.config';
+          return undefined;
+        },
+        load: (file) => {
+          if (file === '/root/.configB')
+            return { extends: '/baseB', port: 8080 };
+          if (file === '/baseB/.config') return { theme: 'light' };
+          return {};
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([providerA, providerB]);
+      const result = aggregate.load('/root');
+
+      // A's extends-derived "theme" wins (first-provider-wins among extends)
+      expect(result.theme).toBe('dark');
+    });
+
     it('should load nested aggregates and merge their provenance', () => {
       const providerA = makeMockProvider({
         '/root/.configA': { foo: 'fromA' },

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
@@ -382,6 +382,193 @@ describe('AggregateConfigProvider', () => {
     });
   });
 
+  describe('updateConfig with default fallback', () => {
+    it('should use default provider when no providers resolve', async () => {
+      const updates: any[] = [];
+      const targetPaths: any[] = [];
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined, // no file exists
+        load: () => ({}),
+        updateConfig: async (updater, options) => {
+          const result =
+            typeof updater === 'function' ? await updater({}) : updater;
+          updates.push(result);
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ foo: 'bar' });
+
+      expect(updates).toEqual([{ foo: 'bar' }]);
+      expect(targetPaths).toEqual(['/tmp/default.json']);
+    });
+
+    it('should support default as a function', async () => {
+      const updates: any[] = [];
+      const targetPaths: any[] = [];
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (updater, options) => {
+          const result =
+            typeof updater === 'function' ? await updater({}) : updater;
+          updates.push(result);
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: () => '/tmp/from-function.json' },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ key: 'value' });
+
+      expect(targetPaths).toEqual(['/tmp/from-function.json']);
+    });
+
+    it('should support async default function', async () => {
+      const targetPaths: any[] = [];
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (updater, options) => {
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        {
+          provider,
+          default: async () => '/tmp/async-default.json',
+        },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ key: 'value' });
+
+      expect(targetPaths).toEqual(['/tmp/async-default.json']);
+    });
+
+    it('should fall through when default function returns null', async () => {
+      const targetPaths: any[] = [];
+
+      const providerA: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (_updater, options) => {
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const providerB: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (_updater, options) => {
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider: providerA, default: () => null },
+        { provider: providerB, default: '/tmp/fallback.json' },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ key: 'value' });
+
+      // Should skip providerA (returned null) and use providerB
+      expect(targetPaths).toEqual(['/tmp/fallback.json']);
+    });
+
+    it('should prefer resolving provider over default provider', async () => {
+      const resolvedUpdates: any[] = [];
+      const defaultUpdates: any[] = [];
+
+      const resolvingProvider: ConfigurationProvider<any> = {
+        resolve: (dir) =>
+          dir === '/root' ? '/root/.config.json' : undefined,
+        load: () => ({ existing: true }),
+        updateConfig: async (updater) => {
+          const result =
+            typeof updater === 'function'
+              ? await updater({ existing: true })
+              : updater;
+          resolvedUpdates.push(result);
+        },
+      };
+
+      const defaultProvider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (updater) => {
+          const result =
+            typeof updater === 'function' ? await updater({}) : updater;
+          defaultUpdates.push(result);
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        resolvingProvider,
+        { provider: defaultProvider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ newKey: 'value' } as any);
+
+      // Should route to resolving provider, not the default one
+      expect(resolvedUpdates).toEqual([
+        { existing: true, newKey: 'value' },
+      ]);
+      expect(defaultUpdates).toEqual([]);
+    });
+
+    it('should throw when no provider resolves and no default is configured', async () => {
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async () => {},
+      };
+
+      const aggregate = new AggregateConfigProvider([provider]);
+      aggregate.load('/root');
+
+      await expect(
+        aggregate.updateConfig({ foo: 'bar' })
+      ).rejects.toThrow(/no provider resolved/);
+    });
+
+    it('should support URL as default', async () => {
+      const targetPaths: any[] = [];
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => ({}),
+        updateConfig: async (_updater, options) => {
+          if (options?.targetPath) targetPaths.push(options.targetPath);
+        },
+      };
+
+      const defaultUrl = new URL('file:///tmp/url-default.json');
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: defaultUrl },
+      ]);
+      aggregate.load('/root');
+
+      await aggregate.updateConfig({ key: 'value' });
+
+      expect(targetPaths).toEqual([defaultUrl]);
+    });
+  });
+
   describe('integration: multi-provider updateConfig routing', () => {
     it('should route updates to correct providers across nested aggregates', async () => {
       const updatesA: any[] = [];

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
@@ -138,6 +138,36 @@ describe('AggregateConfigProvider', () => {
       expect(result).toEqual({ foo: 'root', bar: 'base' });
     });
 
+    it('should handle deeply nested extends chains (A → B → C)', () => {
+      const provider: ConfigurationProvider<any> = {
+        resolve: (dir) => {
+          if (dir === '/root') return '/root/.config';
+          if (dir === '/mid') return '/mid/.config';
+          if (dir === '/base') return '/base/.config';
+          return undefined;
+        },
+        load: (file) => {
+          if (file === '/root/.config')
+            return { extends: '/mid', root: 'root-val' };
+          if (file === '/mid/.config')
+            return { extends: '/base', mid: 'mid-val', root: 'mid-override' };
+          if (file === '/base/.config')
+            return { base: 'base-val', mid: 'base-override', root: 'base-override' };
+          return {};
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([provider]);
+      const result = aggregate.load('/root');
+
+      // root's explicit "root" wins over mid and base
+      expect(result.root).toBe('root-val');
+      // mid's explicit "mid" wins over base
+      expect(result.mid).toBe('mid-val');
+      // base's "base" fills in (no one else set it)
+      expect(result.base).toBe('base-val');
+    });
+
     it('should prioritize explicit values over extends-derived values regardless of provider order', () => {
       // Provider A (first) has extends that brings in "name" from a base config.
       // Provider B (second) explicitly sets "name" in its own config.

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
@@ -669,6 +669,99 @@ describe('AggregateConfigProvider', () => {
 
       expect(targetPaths).toEqual([defaultUrl]);
     });
+
+    it('updater form reads current state from the default-path file when nothing resolves from cwd', async () => {
+      // Simulates the flow: init writes to default path, later call wants
+      // to read-modify-write. Without the fix, the updater sees {}
+      // because load(cwd) finds nothing.
+      let onDisk: Record<string, unknown> = { count: 5 };
+
+      const provider: ConfigurationProvider<any> = {
+        // Never resolves from cwd — config only lives at the default path.
+        resolve: () => undefined,
+        load: (file) => {
+          if (file === '/tmp/default.json') return onDisk as any;
+          return {};
+        },
+        updateConfig: async (updater) => {
+          const next =
+            typeof updater === 'function'
+              ? await (updater as any)(onDisk)
+              : updater;
+          onDisk = next;
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      // Mock existsSync so the fallback path is considered "on disk"
+      const fs = await import('../environment-provider.js');
+      const original = fs.getFileSystemProvider();
+      fs.setFileSystemProvider({
+        ...original,
+        existsSync: (p: string) =>
+          p === '/tmp/default.json' ? true : original.existsSync(p),
+      });
+
+      try {
+        await aggregate.updateConfig((config) => {
+          // Should see the persisted count (5), not undefined
+          (config as any).count = ((config as any).count ?? 0) + 1;
+        });
+      } finally {
+        fs.setFileSystemProvider(original);
+      }
+
+      expect(onDisk).toEqual({ count: 6 });
+    });
+
+    it('updater form strips `extends` from the default-path file when loading current state', async () => {
+      let onDisk: Record<string, unknown> = {
+        extends: './base.json',
+        theme: 'dark',
+      };
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => onDisk as any,
+        updateConfig: async (updater) => {
+          const next =
+            typeof updater === 'function'
+              ? await (updater as any)(onDisk)
+              : updater;
+          onDisk = next;
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      const fs = await import('../environment-provider.js');
+      const original = fs.getFileSystemProvider();
+      fs.setFileSystemProvider({
+        ...original,
+        existsSync: () => true,
+      });
+
+      let seenExtends: unknown;
+      try {
+        await aggregate.updateConfig((config) => {
+          seenExtends = (config as any).extends;
+          (config as any).theme = 'system';
+        });
+      } finally {
+        fs.setFileSystemProvider(original);
+      }
+
+      // The updater should not see `extends` — it's a loader directive,
+      // not a config value.
+      expect(seenExtends).toBeUndefined();
+    });
   });
 
   describe('integration: multi-provider updateConfig routing', () => {

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -38,12 +38,12 @@ export type ConfigUpdater<T> = (current: T) => void;
  * it delegates resolution to its children.
  */
 export class AggregateConfigProvider<T> {
-  readonly providers: AnyConfigProvider<T>[];
+  providers: AnyConfigProvider<T>[];
 
   /**
    * Internal entries storing providers with optional framework metadata.
    */
-  private readonly entries: ProviderEntry<T>[];
+  private entries: ProviderEntry<T>[];
 
   /**
    * After {@link load} is called, maps each top-level key to the leaf
@@ -73,7 +73,7 @@ export class AggregateConfigProvider<T> {
   ) {
     const entry: ProviderEntry<T> = { provider, ...metadata };
     this.entries.push(entry);
-    (this.providers as AnyConfigProvider<T>[]).push(provider);
+    this.providers.push(provider);
   }
 
   /**

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -93,20 +93,24 @@ export class AggregateConfigProvider<T> {
     this.provenance = new Map();
     this.lastConfigurationRoot = configurationRoot;
 
-    const combined: T = {} as T;
+    // Phase 1: Load each provider's own config, separating extends references.
+    // Aggregate children are loaded recursively (they handle extends internally).
+    const results = new Map<
+      AnyConfigProvider<T>,
+      {
+        own: Partial<T>;
+        extendsRef?: string;
+        childProvenance?: Map<string, ConfigurationProvider<T, any>>;
+      }
+    >();
 
     for (const provider of this.providers) {
       if (isAggregateConfigProvider(provider)) {
         const childResult = provider.load(configurationRoot, visitedMap);
-        for (const key of Object.keys(childResult as any)) {
-          if (!(key in (combined as any))) {
-            (combined as any)[key] = (childResult as any)[key];
-            const childOwner = provider.provenance.get(key);
-            if (childOwner) {
-              this.provenance.set(key, childOwner);
-            }
-          }
-        }
+        results.set(provider, {
+          own: childResult,
+          childProvenance: provider.provenance,
+        });
       } else {
         const filename = provider.resolve(configurationRoot);
         if (filename) {
@@ -120,43 +124,67 @@ export class AggregateConfigProvider<T> {
           loaderVisited.add(filenameStr);
           visitedMap.set(provider, loaderVisited);
 
-          const loaded = this.loadWithExtends(
-            filename,
-            provider,
-            configurationRoot,
-            visitedMap
-          );
+          const loaded = provider.load(filename);
+          const { extends: extendsRef, ...own } = loaded as any;
+          results.set(provider, { own, extendsRef });
+        }
+      }
+    }
 
-          for (const key of Object.keys(loaded as any)) {
-            if (!(key in (combined as any))) {
-              (combined as any)[key] = (loaded as any)[key];
-              this.provenance.set(key, provider);
+    // Phase 2: Merge explicit values in registration order (first-wins).
+    // Explicit values from ANY provider beat extends-derived values.
+    let combined: T = {} as T;
+
+    for (const provider of this.providers) {
+      const result = results.get(provider);
+      if (!result) continue;
+
+      for (const key of Object.keys(result.own as any)) {
+        if (!(key in (combined as any))) {
+          (combined as any)[key] = (result.own as any)[key];
+          if (
+            isAggregateConfigProvider(provider) &&
+            result.childProvenance
+          ) {
+            const childOwner = result.childProvenance.get(key);
+            if (childOwner) {
+              this.provenance.set(key, childOwner);
             }
+          } else {
+            this.provenance.set(
+              key,
+              provider as ConfigurationProvider<T, any>
+            );
           }
         }
       }
     }
-    return combined;
-  }
 
-  private loadWithExtends(
-    filename: string | URL,
-    provider: ConfigurationProvider<T, any>,
-    configurationRoot: string,
-    visited: Map<ConfigurationProvider<T, any>, Set<string>>
-  ): T {
-    const loaded = provider.load(filename);
-    if (loaded.extends) {
-      const fs = getFileSystemProvider();
-      const extendsRoot = loaded.extends.startsWith('.')
-        ? fs.join(configurationRoot, loaded.extends)
-        : loaded.extends;
+    // Phase 3: Resolve extends chains and merge base values underneath.
+    // These only fill keys not already set by any explicit value.
+    const fs = getFileSystemProvider();
+    for (const provider of this.providers) {
+      if (isAggregateConfigProvider(provider)) continue;
+      const result = results.get(provider);
+      if (!result?.extendsRef) continue;
+
+      const extendsRoot = result.extendsRef.startsWith('.')
+        ? fs.join(configurationRoot, result.extendsRef)
+        : result.extendsRef;
       const extendsAggregate = new AggregateConfigProvider<T>(this.entries);
-      const extended = extendsAggregate.load(extendsRoot, visited);
-      const { extends: _, ...rest } = loaded as any;
-      return { ...extended, ...rest } as T;
+      const extended = extendsAggregate.load(extendsRoot, visitedMap);
+      for (const key of Object.keys(extended as any)) {
+        if (!(key in (combined as any))) {
+          (combined as any)[key] = (extended as any)[key];
+          this.provenance.set(
+            key,
+            provider as ConfigurationProvider<T, any>
+          );
+        }
+      }
     }
-    return loaded;
+
+    return combined;
   }
 
   /**

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -38,7 +38,13 @@ export type ConfigUpdater<T> = (current: T) => void;
  * it delegates resolution to its children.
  */
 export class AggregateConfigProvider<T> {
-  providers: AnyConfigProvider<T>[];
+  /**
+   * The list of child providers, derived from {@link entries}.
+   * Read-only to prevent desync with the entries array.
+   */
+  get providers(): ReadonlyArray<AnyConfigProvider<T>> {
+    return this.entries.map((e) => e.provider);
+  }
 
   /**
    * Internal entries storing providers with optional framework metadata.
@@ -61,7 +67,6 @@ export class AggregateConfigProvider<T> {
     this.entries = providers.map((p) =>
       isProviderEntry(p) ? p : { provider: p }
     );
-    this.providers = this.entries.map((e) => e.provider);
   }
 
   /**
@@ -73,7 +78,6 @@ export class AggregateConfigProvider<T> {
   ) {
     const entry: ProviderEntry<T> = { provider, ...metadata };
     this.entries.push(entry);
-    this.providers.push(provider);
   }
 
   /**
@@ -268,7 +272,7 @@ export class AggregateConfigProvider<T> {
     for (const [provider, { partial, targetPath }] of updatesByProvider) {
       promises.push(
         provider.updateConfig!(
-          (current) => ({ ...current, ...partial }),
+          (current) => ({ ...(current ?? ({} as T)), ...partial }),
           targetPath ? { targetPath } : undefined
         )
       );

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -1,12 +1,26 @@
 import { getFileSystemProvider } from '../environment-provider.js';
-import { ConfigurationProvider, ConfigurationDocSection } from './configuration-loader.js';
+import {
+  ConfigurationProvider,
+  ConfigurationDocSection,
+  DefaultConfig,
+} from './configuration-loader.js';
+import { toFilePath } from './utils.js';
 
 /**
  * A provider child is either a single-file ConfigurationProvider or a nested AggregateConfigProvider.
  */
 export type AnyConfigProvider<T> =
-  | ConfigurationProvider<T>
+  | ConfigurationProvider<T, any>
   | AggregateConfigProvider<T>;
+
+/**
+ * A provider entry pairs a provider with optional framework-level metadata.
+ */
+export type ProviderEntry<T> = {
+  provider: AnyConfigProvider<T>;
+  /** Framework-level default path for when no config file exists on disk. */
+  default?: DefaultConfig<any>;
+};
 
 /**
  * An updater function that receives the current merged configuration
@@ -27,10 +41,15 @@ export class AggregateConfigProvider<T> {
   readonly providers: AnyConfigProvider<T>[];
 
   /**
+   * Internal entries storing providers with optional framework metadata.
+   */
+  private readonly entries: ProviderEntry<T>[];
+
+  /**
    * After {@link load} is called, maps each top-level key to the leaf
    * {@link ConfigurationProvider} that supplied it.
    */
-  provenance: Map<string, ConfigurationProvider<T>> = new Map();
+  provenance: Map<string, ConfigurationProvider<T, any>> = new Map();
 
   /**
    * The last configuration root passed to {@link load}, stored for
@@ -38,8 +57,23 @@ export class AggregateConfigProvider<T> {
    */
   private lastConfigurationRoot?: string;
 
-  constructor(providers: AnyConfigProvider<T>[]) {
-    this.providers = providers;
+  constructor(providers: (AnyConfigProvider<T> | ProviderEntry<T>)[]) {
+    this.entries = providers.map((p) =>
+      isProviderEntry(p) ? p : { provider: p }
+    );
+    this.providers = this.entries.map((e) => e.provider);
+  }
+
+  /**
+   * Adds a provider with optional framework metadata.
+   */
+  addProvider(
+    provider: AnyConfigProvider<T>,
+    metadata?: { default?: DefaultConfig<any> }
+  ) {
+    const entry: ProviderEntry<T> = { provider, ...metadata };
+    this.entries.push(entry);
+    (this.providers as AnyConfigProvider<T>[]).push(provider);
   }
 
   /**
@@ -52,10 +86,10 @@ export class AggregateConfigProvider<T> {
    */
   load(
     configurationRoot: string,
-    visited?: Map<ConfigurationProvider<T>, Set<string>>
+    visited?: Map<ConfigurationProvider<T, any>, Set<string>>
   ): T {
     const visitedMap =
-      visited ?? new Map<ConfigurationProvider<T>, Set<string>>();
+      visited ?? new Map<ConfigurationProvider<T, any>, Set<string>>();
     this.provenance = new Map();
     this.lastConfigurationRoot = configurationRoot;
 
@@ -76,13 +110,14 @@ export class AggregateConfigProvider<T> {
       } else {
         const filename = provider.resolve(configurationRoot);
         if (filename) {
+          const filenameStr = toFilePath(filename);
           const loaderVisited = visitedMap.get(provider) ?? new Set<string>();
-          if (loaderVisited.has(filename)) {
+          if (loaderVisited.has(filenameStr)) {
             throw new Error(
-              `Circular reference detected in configuration file: ${filename}. This is likely caused by an "extends" property pointing to a directory which doesn't contain a configuration file.`
+              `Circular reference detected in configuration file: ${filenameStr}. This is likely caused by an "extends" property pointing to a directory which doesn't contain a configuration file.`
             );
           }
-          loaderVisited.add(filename);
+          loaderVisited.add(filenameStr);
           visitedMap.set(provider, loaderVisited);
 
           const loaded = this.loadWithExtends(
@@ -105,10 +140,10 @@ export class AggregateConfigProvider<T> {
   }
 
   private loadWithExtends(
-    filename: string,
-    provider: ConfigurationProvider<T>,
+    filename: string | URL,
+    provider: ConfigurationProvider<T, any>,
     configurationRoot: string,
-    visited: Map<ConfigurationProvider<T>, Set<string>>
+    visited: Map<ConfigurationProvider<T, any>, Set<string>>
   ): T {
     const loaded = provider.load(filename);
     if (loaded.extends) {
@@ -116,7 +151,7 @@ export class AggregateConfigProvider<T> {
       const extendsRoot = loaded.extends.startsWith('.')
         ? fs.join(configurationRoot, loaded.extends)
         : loaded.extends;
-      const extendsAggregate = new AggregateConfigProvider<T>(this.providers);
+      const extendsAggregate = new AggregateConfigProvider<T>(this.entries);
       const extended = extendsAggregate.load(extendsRoot, visited);
       const { extends: _, ...rest } = loaded as any;
       return { ...extended, ...rest } as T;
@@ -127,6 +162,8 @@ export class AggregateConfigProvider<T> {
   /**
    * Updates configuration by routing each key to its owning provider.
    * Keys not found in provenance are routed to the first resolving provider.
+   * If no provider resolves, attempts to use a provider with a `default` config
+   * to create a new configuration file.
    *
    * @param values Partial configuration to write.
    */
@@ -150,14 +187,28 @@ export class AggregateConfigProvider<T> {
     }
 
     // Group keys by their owning provider
-    const updatesByProvider = new Map<ConfigurationProvider<T>, Partial<T>>();
+    const updatesByProvider = new Map<
+      ConfigurationProvider<T, any>,
+      { partial: Partial<T>; targetPath?: string | URL }
+    >();
 
     // Find the first leaf provider that resolves (fallback for new keys)
-    let fallbackProvider: ConfigurationProvider<T> | undefined;
+    let fallbackProvider: ConfigurationProvider<T, any> | undefined;
+    let fallbackTargetPath: (string | URL) | undefined;
+
     if (this.lastConfigurationRoot) {
       fallbackProvider = this.findFirstResolvingProvider(
         this.lastConfigurationRoot
       );
+    }
+
+    // If no provider resolves, try to find one with a default
+    if (!fallbackProvider) {
+      const defaultResult = await this.resolveDefaultProvider();
+      if (defaultResult) {
+        fallbackProvider = defaultResult.provider;
+        fallbackTargetPath = defaultResult.targetPath;
+      }
     }
 
     for (const key of Object.keys(values) as (keyof T & string)[]) {
@@ -173,16 +224,25 @@ export class AggregateConfigProvider<T> {
           `Cannot update config key "${key}": the owning provider does not implement updateConfig.`
         );
       }
-      const existing = updatesByProvider.get(owner) ?? ({} as Partial<T>);
-      (existing as any)[key] = values[key];
+      const existing = updatesByProvider.get(owner) ?? {
+        partial: {} as Partial<T>,
+      };
+      (existing.partial as any)[key] = values[key];
+      // Attach targetPath only for the fallback provider when using default
+      if (owner === fallbackProvider && fallbackTargetPath) {
+        existing.targetPath = fallbackTargetPath;
+      }
       updatesByProvider.set(owner, existing);
     }
 
     // Call each provider's updateConfig with an updater that merges the partial update
     const promises: Promise<void>[] = [];
-    for (const [provider, partial] of updatesByProvider) {
+    for (const [provider, { partial, targetPath }] of updatesByProvider) {
       promises.push(
-        provider.updateConfig!((current) => ({ ...current, ...partial }))
+        provider.updateConfig!(
+          (current) => ({ ...current, ...partial }),
+          targetPath ? { targetPath } : undefined
+        )
       );
     }
     await Promise.all(promises);
@@ -214,15 +274,65 @@ export class AggregateConfigProvider<T> {
     return changes;
   }
 
+  /**
+   * Finds the first leaf provider that resolves a file in the given root.
+   */
   private findFirstResolvingProvider(
     configurationRoot: string
-  ): ConfigurationProvider<T> | undefined {
+  ): ConfigurationProvider<T, any> | undefined {
     for (const provider of this.providers) {
       if (isAggregateConfigProvider(provider)) {
         const found = provider.findFirstResolvingProvider(configurationRoot);
         if (found) return found;
       } else {
         if (provider.resolve(configurationRoot)) return provider;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Iterates entries looking for the first provider with a `default` config
+   * that resolves to a non-null path. Returns the provider and resolved path.
+   */
+  private async resolveDefaultProvider(): Promise<
+    | { provider: ConfigurationProvider<T, any>; targetPath: string | URL }
+    | undefined
+  > {
+    for (const entry of this.entries) {
+      if (entry.default == null) continue;
+
+      const provider = isAggregateConfigProvider(entry.provider)
+        ? // For aggregate entries with a default, find the first leaf provider
+          this.findFirstLeafProvider(entry.provider)
+        : entry.provider;
+
+      if (!provider || !provider.updateConfig) continue;
+
+      const resolved =
+        typeof entry.default === 'function'
+          ? await entry.default()
+          : entry.default;
+
+      if (resolved != null) {
+        return { provider, targetPath: resolved };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Finds the first non-aggregate leaf provider in a nested structure.
+   */
+  private findFirstLeafProvider(
+    aggregate: AggregateConfigProvider<T>
+  ): ConfigurationProvider<T, any> | undefined {
+    for (const provider of aggregate.providers) {
+      if (isAggregateConfigProvider(provider)) {
+        const found = this.findFirstLeafProvider(provider);
+        if (found) return found;
+      } else {
+        return provider;
       }
     }
     return undefined;
@@ -251,4 +361,18 @@ export function isAggregateConfigProvider<T>(
   provider: AnyConfigProvider<T>
 ): provider is AggregateConfigProvider<T> {
   return provider instanceof AggregateConfigProvider;
+}
+
+/**
+ * Type guard to distinguish a ProviderEntry from a bare provider.
+ */
+function isProviderEntry<T>(
+  value: AnyConfigProvider<T> | ProviderEntry<T>
+): value is ProviderEntry<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'provider' in value &&
+    !(value instanceof AggregateConfigProvider)
+  );
 }

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -17,6 +17,14 @@ type AnyProvider<T> = ConfigurationProvider<T, any>;
 export type AnyConfigProvider<T> = AnyProvider<T> | AggregateConfigProvider<T>;
 
 /**
+ * A config registration can be a single provider or multiple providers.
+ * Parser/CLI registration APIs normalize arrays into separate provider entries.
+ */
+export type ConfigProviderRegistration<T> =
+  | AnyConfigProvider<T>
+  | readonly AnyConfigProvider<T>[];
+
+/**
  * A provider entry pairs a provider with optional framework-level metadata.
  */
 export type ProviderEntry<T> = {

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -7,6 +7,19 @@ import {
 import { toFilePath } from './utils.js';
 
 /**
+ * Returns true when an object has no own enumerable properties. Used to
+ * detect "nothing resolved from cwd" in {@link AggregateConfigProvider.updateConfig}
+ * so the updater form can fall back to reading the default-path file.
+ */
+function isEmptyObject(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value as object).length === 0
+  );
+}
+
+/**
  * A leaf ConfigurationProvider with any location type.
  */
 type AnyProvider<T> = ConfigurationProvider<T, any>;
@@ -224,7 +237,7 @@ export class AggregateConfigProvider<T> {
   ): Promise<void> {
     let values: Partial<T>;
     if (typeof valuesOrUpdater === 'function') {
-      values = this.trackUpdates(valuesOrUpdater);
+      values = await this.trackUpdates(valuesOrUpdater);
     } else {
       values = valuesOrUpdater;
     }
@@ -294,15 +307,57 @@ export class AggregateConfigProvider<T> {
   /**
    * Runs an updater function against a proxy of the merged config,
    * returning only the properties that were set during the callback.
+   *
+   * The proxy target is computed from:
+   *
+   * 1. The merged result of {@link load} against the current configuration
+   *    root. This sees any provider whose `resolve()` finds a file.
+   * 2. As a fallback, the default-path file of the first provider with a
+   *    `default` option, if that file exists on disk. This allows
+   *    read-modify-write updaters to see the most recently persisted
+   *    state even when the file lives outside the configuration root
+   *    (e.g. a user-level config in `~/.config/my-tool/config.json`).
+   *
+   * Without (2), a sequence like `init` → write via default path →
+   * later `app.updateConfig(config => config.count + 1)` would always
+   * see `count === undefined` because `load(cwd)` never touches the
+   * default-path file.
    */
-  private trackUpdates(updater: ConfigUpdater<T>): Partial<T> {
+  private async trackUpdates(
+    updater: ConfigUpdater<T>
+  ): Promise<Partial<T>> {
     if (!this.lastConfigurationRoot) {
       throw new Error(
         'Cannot use updater function: config has not been loaded yet. Call load() first.'
       );
     }
     // Re-load to get the current merged config
-    const current = this.load(this.lastConfigurationRoot);
+    let current = this.load(this.lastConfigurationRoot);
+
+    // Nothing resolved from cwd — try the default-path file as a fallback.
+    // This keeps updater-form reads consistent with updateConfig writes
+    // when the only on-disk config lives at a framework-managed default.
+    if (isEmptyObject(current) && this.provenance.size === 0) {
+      const defaultResult = await this.resolveDefaultProvider();
+      if (defaultResult) {
+        const fs = getFileSystemProvider();
+        const path = toFilePath(defaultResult.targetPath);
+        if (fs.existsSync(path)) {
+          try {
+            const loaded = defaultResult.provider.load(path);
+            const { extends: _extendsIgnored, ...rest } = (loaded ?? {}) as {
+              extends?: string;
+            } & T;
+            current = rest as T;
+          } catch {
+            // Failed to read the default-path file — leave `current` as the
+            // empty object that load() returned. The updater will see {}
+            // and can fall back to its own defaults.
+          }
+        }
+      }
+    }
+
     const changes: Partial<T> = {} as Partial<T>;
     const proxy = new Proxy(current as object, {
       set(_target, prop, value) {

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -7,11 +7,14 @@ import {
 import { toFilePath } from './utils.js';
 
 /**
+ * A leaf ConfigurationProvider with any location type.
+ */
+type AnyProvider<T> = ConfigurationProvider<T, any>;
+
+/**
  * A provider child is either a single-file ConfigurationProvider or a nested AggregateConfigProvider.
  */
-export type AnyConfigProvider<T> =
-  | ConfigurationProvider<T, any>
-  | AggregateConfigProvider<T>;
+export type AnyConfigProvider<T> = AnyProvider<T> | AggregateConfigProvider<T>;
 
 /**
  * A provider entry pairs a provider with optional framework-level metadata.
@@ -55,7 +58,7 @@ export class AggregateConfigProvider<T> {
    * After {@link load} is called, maps each top-level key to the leaf
    * {@link ConfigurationProvider} that supplied it.
    */
-  provenance: Map<string, ConfigurationProvider<T, any>> = new Map();
+  provenance: Map<string, AnyProvider<T>> = new Map();
 
   /**
    * The last configuration root passed to {@link load}, stored for
@@ -90,10 +93,10 @@ export class AggregateConfigProvider<T> {
    */
   load(
     configurationRoot: string,
-    visited?: Map<ConfigurationProvider<T, any>, Set<string>>
+    visited?: Map<AnyProvider<T>, Set<string>>
   ): T {
     const visitedMap =
-      visited ?? new Map<ConfigurationProvider<T, any>, Set<string>>();
+      visited ?? new Map<AnyProvider<T>, Set<string>>();
     this.provenance = new Map();
     this.lastConfigurationRoot = configurationRoot;
 
@@ -104,7 +107,7 @@ export class AggregateConfigProvider<T> {
       {
         own: Partial<T>;
         extendsRef?: string;
-        childProvenance?: Map<string, ConfigurationProvider<T, any>>;
+        childProvenance?: Map<string, AnyProvider<T>>;
       }
     >();
 
@@ -157,7 +160,7 @@ export class AggregateConfigProvider<T> {
           } else {
             this.provenance.set(
               key,
-              provider as ConfigurationProvider<T, any>
+              provider as AnyProvider<T>
             );
           }
         }
@@ -182,7 +185,7 @@ export class AggregateConfigProvider<T> {
           (combined as any)[key] = (extended as any)[key];
           this.provenance.set(
             key,
-            provider as ConfigurationProvider<T, any>
+            provider as AnyProvider<T>
           );
         }
       }
@@ -220,12 +223,12 @@ export class AggregateConfigProvider<T> {
 
     // Group keys by their owning provider
     const updatesByProvider = new Map<
-      ConfigurationProvider<T, any>,
+      AnyProvider<T>,
       { partial: Partial<T>; targetPath?: string | URL }
     >();
 
     // Find the first leaf provider that resolves (fallback for new keys)
-    let fallbackProvider: ConfigurationProvider<T, any> | undefined;
+    let fallbackProvider: AnyProvider<T> | undefined;
     let fallbackTargetPath: (string | URL) | undefined;
 
     if (this.lastConfigurationRoot) {
@@ -311,7 +314,7 @@ export class AggregateConfigProvider<T> {
    */
   private findFirstResolvingProvider(
     configurationRoot: string
-  ): ConfigurationProvider<T, any> | undefined {
+  ): AnyProvider<T> | undefined {
     for (const provider of this.providers) {
       if (isAggregateConfigProvider(provider)) {
         const found = provider.findFirstResolvingProvider(configurationRoot);
@@ -328,7 +331,7 @@ export class AggregateConfigProvider<T> {
    * that resolves to a non-null path. Returns the provider and resolved path.
    */
   private async resolveDefaultProvider(): Promise<
-    | { provider: ConfigurationProvider<T, any>; targetPath: string | URL }
+    | { provider: AnyProvider<T>; targetPath: string | URL }
     | undefined
   > {
     for (const entry of this.entries) {
@@ -358,7 +361,7 @@ export class AggregateConfigProvider<T> {
    */
   private findFirstLeafProvider(
     aggregate: AggregateConfigProvider<T>
-  ): ConfigurationProvider<T, any> | undefined {
+  ): AnyProvider<T> | undefined {
     for (const provider of aggregate.providers) {
       if (isAggregateConfigProvider(provider)) {
         const found = this.findFirstLeafProvider(provider);

--- a/packages/parser/src/lib/config-files/configuration-loader.ts
+++ b/packages/parser/src/lib/config-files/configuration-loader.ts
@@ -11,22 +11,27 @@ export type ConfigurationDocSection = {
 
 /**
  * Implement this type to create a custom configuration provider.
+ *
+ * @typeParam T The configuration object type.
+ * @typeParam TLocation The type used to represent file paths. Defaults to `string | URL`.
+ *   Providers that only work with filesystem paths can narrow this to `string`.
+ *   ESM-friendly providers should keep the default to support `file://` URLs.
  */
-export type ConfigurationProvider<T> = {
+export type ConfigurationProvider<T, TLocation = string | URL> = {
   /**
    * A function that searches for a configuration file in the given directory and returns the path to the file.
    * Should handle being passed either a directory to search, or a file to check.
    * @param configurationRoot
    * @returns The path to the configuration file, or undefined if no applicable file was found.
    */
-  resolve: (configurationRoot: string) => string | undefined;
+  resolve: (configurationRoot: string) => TLocation | undefined;
 
   /**
    * A function that loads the configuration from the given file.
    * @param filename The path to the configuration file (resolved by {@link ConfigurationProvider#resolve}).
    * @returns The loaded configuration object.
    */
-  load: (filename: string) => T & { extends?: string };
+  load: (filename: TLocation) => T & { extends?: string };
 
   /**
    * Updates the configuration file managed by this provider.
@@ -34,9 +39,14 @@ export type ConfigurationProvider<T> = {
    * that receives the current configuration and returns the new configuration.
    *
    * @param configOrUpdater A configuration object to write, or a function that receives the current config and returns the updated config.
+   * @param options Optional settings for the update.
+   * @param options.targetPath When provided by the framework (e.g., from a resolved `default` config option),
+   *   the provider should write to this path instead of using {@link resolve}. If the file does not exist,
+   *   the provider should create it (including parent directories).
    */
   updateConfig?: (
-    configOrUpdater: T | ((current: T) => T | Promise<T>)
+    configOrUpdater: T | ((current: T) => T | Promise<T>),
+    options?: { targetPath?: TLocation }
   ) => Promise<void>;
 
   /**
@@ -46,3 +56,23 @@ export type ConfigurationProvider<T> = {
    */
   describeConfig?: () => ConfigurationDocSection;
 };
+
+/**
+ * Extracts the `TLocation` type parameter from a {@link ConfigurationProvider}.
+ */
+export type ExtractLocation<P> = P extends ConfigurationProvider<any, infer TLoc>
+  ? TLoc
+  : string | URL;
+
+/**
+ * A default config path specification. Used as a framework-level option in `.config()` calls
+ * to specify where a config file should be created when none exists on disk.
+ *
+ * - Static value: a path or URL to use directly.
+ * - Function: called lazily; return `null` to fall through to the next provider.
+ *
+ * @typeParam TLocation The location type (usually `string | URL`).
+ */
+export type DefaultConfig<TLocation = string | URL> =
+  | TLocation
+  | (() => TLocation | null | Promise<TLocation | null>);

--- a/packages/parser/src/lib/config-files/json-file-loader.spec.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { getJsonFileConfigLoader } from './json-file-loader.js';
+import {
+  getJsonFileConfigLoader,
+  JsonFileConfigLoader,
+} from './json-file-loader.js';
 import { isAggregateConfigProvider } from './aggregate-config-provider.js';
 
 describe('getJsonFileConfigLoader', () => {
@@ -12,5 +15,16 @@ describe('getJsonFileConfigLoader', () => {
   it('should return an AggregateConfigProvider for multiple filenames', () => {
     const loader = getJsonFileConfigLoader(['config.json', 'alt.config.json']);
     expect(isAggregateConfigProvider(loader)).toBe(true);
+  });
+
+  it('should construct multiple leaf providers for multiple filenames', () => {
+    const loaders = new JsonFileConfigLoader({
+      filename: ['config.json', 'alt.config.json'],
+    });
+
+    expect(Array.isArray(loaders)).toBe(true);
+    expect(loaders).toHaveLength(2);
+    expect(loaders[0]).toHaveProperty('resolve');
+    expect(isAggregateConfigProvider(loaders[0])).toBe(false);
   });
 });

--- a/packages/parser/src/lib/config-files/json-file-loader.spec.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.spec.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getJsonFileConfigLoader,
   JsonFileConfigLoader,
 } from './json-file-loader.js';
 import { isAggregateConfigProvider } from './aggregate-config-provider.js';
+import {
+  MemoryEnvironmentProvider,
+  MemoryFileSystemProvider,
+  getEnvironmentProvider,
+  getFileSystemProvider,
+  setEnvironmentProvider,
+  setFileSystemProvider,
+} from '../environment-provider.js';
 
 describe('getJsonFileConfigLoader', () => {
   it('should return a ConfigurationProvider for a single filename', () => {
@@ -26,5 +34,185 @@ describe('getJsonFileConfigLoader', () => {
     expect(loaders).toHaveLength(2);
     expect(loaders[0]).toHaveProperty('resolve');
     expect(isAggregateConfigProvider(loaders[0])).toBe(false);
+  });
+});
+
+describe('JsonFileConfigLoader updateConfig', () => {
+  let originalEnv: ReturnType<typeof getEnvironmentProvider>;
+  let originalFs: ReturnType<typeof getFileSystemProvider>;
+  let fs: MemoryFileSystemProvider;
+
+  beforeEach(() => {
+    originalEnv = getEnvironmentProvider();
+    originalFs = getFileSystemProvider();
+    fs = new MemoryFileSystemProvider();
+    setEnvironmentProvider(new MemoryEnvironmentProvider({ cwd: '/root' }));
+    setFileSystemProvider(fs);
+  });
+
+  afterEach(() => {
+    setEnvironmentProvider(originalEnv);
+    setFileSystemProvider(originalFs);
+  });
+
+  it('updates an existing file resolved from cwd', async () => {
+    fs.writeFileSync(
+      '/root/app.config.json',
+      JSON.stringify({ theme: 'light', lang: 'en' })
+    );
+    const loader = new JsonFileConfigLoader<{ theme: string; lang: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!({ theme: 'dark', lang: 'fr' });
+
+    const written = JSON.parse(fs.readFileSync('/root/app.config.json'));
+    expect(written).toEqual({ theme: 'dark', lang: 'fr' });
+  });
+
+  it('creates a new file at targetPath when none exists', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    expect(fs.existsSync('/fresh/app.config.json')).toBe(true);
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('passes an empty object to the updater when creating a fresh file at targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ count: number; name: string }>({
+      filename: 'app.config.json',
+    });
+
+    let receivedCurrent: any;
+    await loader.updateConfig!(
+      (current) => {
+        receivedCurrent = current;
+        return { count: 1, name: 'seeded' };
+      },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    expect(receivedCurrent).toEqual({});
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      count: 1,
+      name: 'seeded',
+    });
+  });
+
+  it('creates parent directories when targetPath points into a nested folder', async () => {
+    let recursiveRequested = false;
+    const delegate = fs;
+    setFileSystemProvider({
+      ...delegate,
+      existsSync: (p) => delegate.existsSync(p),
+      readFileSync: (p) => delegate.readFileSync(p),
+      writeFileSync: (p, d) => delegate.writeFileSync(p, d),
+      writeFile: (p, d) => delegate.writeFile(p, d),
+      appendFileSync: (p, d) => delegate.appendFileSync(p, d),
+      readdirSync: (p) => delegate.readdirSync(p),
+      mkdirSync: (dir, options) => {
+        if (options?.recursive) recursiveRequested = true;
+        delegate.mkdirSync(dir, options);
+      },
+      join: (...p) => delegate.join(...p),
+      resolve: (...p) => delegate.resolve(...p),
+      dirname: (p) => delegate.dirname(p),
+      basename: (p) => delegate.basename(p),
+    });
+
+    const loader = new JsonFileConfigLoader<{ port: number }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { port: 3000 },
+      { targetPath: '/home/user/.config/my-tool/app.config.json' }
+    );
+
+    expect(recursiveRequested).toBe(true);
+  });
+
+  it('prefers resolved file over targetPath when the file already exists there', async () => {
+    fs.writeFileSync(
+      '/fresh/app.config.json',
+      JSON.stringify({ theme: 'light' })
+    );
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    // File exists at targetPath so its contents are merged with the update
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('supports URL as targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: new URL('file:///fresh/via-url.json') }
+    );
+
+    expect(fs.existsSync('/fresh/via-url.json')).toBe(true);
+    expect(JSON.parse(fs.readFileSync('/fresh/via-url.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('throws when no file resolves and no targetPath is provided', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await expect(loader.updateConfig!({ theme: 'dark' })).rejects.toThrow(
+      /Could not resolve configuration file/
+    );
+  });
+
+  it('throws when transform is used without writeTransform', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+      transform: (json) => json.section,
+    });
+
+    await expect(
+      loader.updateConfig!(
+        { theme: 'dark' },
+        { targetPath: '/fresh/app.config.json' }
+      )
+    ).rejects.toThrow(/write transform/);
+  });
+
+  it('applies writeTransform when the file is created at targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+      transform: (json) => json.section ?? {},
+      writeTransform: (json, config) => ({ ...json, section: config }),
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/wrapped.json' }
+    );
+
+    const written = JSON.parse(fs.readFileSync('/fresh/wrapped.json'));
+    expect(written).toEqual({ section: { theme: 'dark' } });
   });
 });

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -170,6 +170,9 @@ type JsonFileConfigLoaderConstructor = {
   new <T>(
     options: JsonFileConfigLoaderMultiOptions<T>
   ): readonly JsonFileConfigLoader<T>[];
+  new <T>(options: JsonFileConfigLoaderOptions<T>):
+    | JsonFileConfigLoader<T>
+    | readonly JsonFileConfigLoader<T>[];
 };
 
 /**

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -75,10 +75,7 @@ class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
   }
 
   resolve(configurationRoot: string): string | undefined {
-    const nearestFile = traverseForFile(
-      this.singleFilename,
-      configurationRoot
-    );
+    const nearestFile = traverseForFile(this.singleFilename, configurationRoot);
     if (nearestFile && nearestFile.endsWith('.json')) {
       return nearestFile;
     }
@@ -113,7 +110,9 @@ class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
 
     if (!resolvedPath) {
       throw new Error(
-        `Could not resolve configuration file "${this.singleFilename}" from ${env.cwd()}`
+        `Could not resolve configuration file "${
+          this.singleFilename
+        }" from ${env.cwd()}`
       );
     }
 
@@ -140,7 +139,10 @@ class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
       fs.mkdirSync(fs.dirname(resolvedPath), { recursive: true });
     }
 
-    await fs.writeFile(resolvedPath, JSON.stringify(outputJson, null, 2) + '\n');
+    await fs.writeFile(
+      resolvedPath,
+      JSON.stringify(outputJson, null, 2) + '\n'
+    );
   }
 
   describeConfig(): ConfigurationDocSection {
@@ -163,8 +165,11 @@ class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
 
 type JsonFileConfigLoaderConstructor = {
   new <T>(
-    options: JsonFileConfigLoaderOptions<T>
-  ): JsonFileConfigLoader<T> | readonly JsonFileConfigLoader<T>[];
+    options: JsonFileConfigLoaderSingleOptions<T>
+  ): JsonFileConfigLoader<T>;
+  new <T>(
+    options: JsonFileConfigLoaderMultiOptions<T>
+  ): readonly JsonFileConfigLoader<T>[];
 };
 
 /**

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -15,14 +15,17 @@ import {
 import { toFilePath, traverseForFile } from './utils.js';
 
 /**
- * Options for constructing a {@link JsonFileConfigLoader}.
+ * Options for constructing a single-file {@link JsonFileConfigLoader}.
+ * For multiple candidate filenames, use {@link getJsonFileConfigLoader} with
+ * its `string[]` overload, which returns an {@link AggregateConfigProvider}.
  */
 export type JsonFileConfigLoaderOptions<T> = {
   /**
-   * The filename (or array of filenames) to search for.
-   * When an array is provided, the factory returns an {@link AggregateConfigProvider}.
+   * The filename to search for. The {@link JsonFileConfigLoader} constructor
+   * only accepts a single filename. For multiple filenames, use
+   * {@link getJsonFileConfigLoader} which wraps each in its own loader.
    */
-  filename: string | string[];
+  filename: string;
   /**
    * Optional transform applied when loading — extracts the desired config shape from the raw JSON.
    */

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -15,17 +15,15 @@ import {
 import { toFilePath, traverseForFile } from './utils.js';
 
 /**
- * Options for constructing a single-file {@link JsonFileConfigLoader}.
- * For multiple candidate filenames, use {@link getJsonFileConfigLoader} with
- * its `string[]` overload, which returns an {@link AggregateConfigProvider}.
+ * Options for constructing a {@link JsonFileConfigLoader}.
  */
 export type JsonFileConfigLoaderOptions<T> = {
   /**
-   * The filename to search for. The {@link JsonFileConfigLoader} constructor
-   * only accepts a single filename. For multiple filenames, use
-   * {@link getJsonFileConfigLoader} which wraps each in its own loader.
+   * The filename (or array of filenames) to search for.
+   * When multiple filenames are provided, `resolve` tries each in order
+   * and returns the first match found while walking up the directory tree.
    */
-  filename: string;
+  filename: string | string[];
   /**
    * Optional transform applied when loading — extracts the desired config shape from the raw JSON.
    */
@@ -44,34 +42,29 @@ function loadJsonFile(filepath: string) {
 
 /**
  * A configuration provider that loads configuration from a JSON file.
- * Supports `file://` URLs for ESM-friendly usage.
+ * Supports multiple candidate filenames and `file://` URLs.
  */
 export class JsonFileConfigLoader<T>
   implements ConfigurationProvider<T, string | URL>
 {
-  private readonly singleFilename: string;
+  private readonly filenames: string[];
   private readonly transform?: (json: any) => T;
   private readonly writeTransform?: (json: any, config: T) => any;
 
   constructor(options: JsonFileConfigLoaderOptions<T>) {
-    if (Array.isArray(options.filename)) {
-      throw new Error(
-        'JsonFileConfigLoader does not accept an array of filenames. ' +
-          'Use getJsonFileConfigLoader() or pass a single filename.'
-      );
-    }
-    this.singleFilename = options.filename;
+    this.filenames = Array.isArray(options.filename)
+      ? options.filename
+      : [options.filename];
     this.transform = options.transform;
     this.writeTransform = options.writeTransform;
   }
 
   resolve(configurationRoot: string): string | undefined {
-    const nearestFile = traverseForFile(
-      this.singleFilename,
-      configurationRoot
-    );
-    if (nearestFile && nearestFile.endsWith('.json')) {
-      return nearestFile;
+    for (const filename of this.filenames) {
+      const nearestFile = traverseForFile(filename, configurationRoot);
+      if (nearestFile && nearestFile.endsWith('.json')) {
+        return nearestFile;
+      }
     }
     return undefined;
   }
@@ -103,7 +96,7 @@ export class JsonFileConfigLoader<T>
 
     if (!resolvedPath) {
       throw new Error(
-        `Could not resolve configuration file "${this.singleFilename}" from ${env.cwd()}`
+        `Could not resolve configuration file "${this.filenames.join(', ')}" from ${env.cwd()}`
       );
     }
 
@@ -134,10 +127,17 @@ export class JsonFileConfigLoader<T>
   }
 
   describeConfig(): ConfigurationDocSection {
+    const filenameDisplay =
+      this.filenames.length === 1
+        ? `\`${this.filenames[0]}\``
+        : this.filenames.map((f) => `\`${f}\``).join(', ');
     const parts: string[] = [
-      `Searches for \`${this.singleFilename}\``,
+      `Searches for ${filenameDisplay}`,
       'Resolution walks up the directory tree from the working directory, using the nearest match.',
     ];
+    if (this.filenames.length > 1) {
+      parts.push('Filenames are tried in order; the first match wins.');
+    }
     if (this.transform) {
       parts.push(
         'A transform is applied to extract configuration from the file.'
@@ -145,13 +145,13 @@ export class JsonFileConfigLoader<T>
     }
     parts.push('Supports `"extends"` for configuration inheritance.');
     return {
-      heading: `JSON File: ${this.singleFilename}`,
+      heading: `JSON File: ${this.filenames.join(', ')}`,
       body: parts.join('\n\n'),
     };
   }
 
   [inspect.custom]() {
-    return 'JsonFileConfigLoader: ' + this.singleFilename;
+    return 'JsonFileConfigLoader: ' + this.filenames.join(', ');
   }
 }
 

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -163,11 +163,8 @@ class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
 
 type JsonFileConfigLoaderConstructor = {
   new <T>(
-    options: JsonFileConfigLoaderSingleOptions<T>
-  ): JsonFileConfigLoader<T>;
-  new <T>(
-    options: JsonFileConfigLoaderMultiOptions<T>
-  ): JsonFileConfigLoader<T>[];
+    options: JsonFileConfigLoaderOptions<T>
+  ): JsonFileConfigLoader<T> | readonly JsonFileConfigLoader<T>[];
 };
 
 /**

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -1,4 +1,9 @@
-import { getEnvironmentProvider, getFileSystemProvider } from '../environment-provider.js';
+import { inspect } from 'node:util';
+
+import {
+  getEnvironmentProvider,
+  getFileSystemProvider,
+} from '../environment-provider.js';
 import {
   AggregateConfigProvider,
   AnyConfigProvider,
@@ -7,7 +12,145 @@ import {
   ConfigurationDocSection,
   ConfigurationProvider,
 } from './configuration-loader.js';
-import { traverseForFile } from './utils.js';
+import { toFilePath, traverseForFile } from './utils.js';
+
+/**
+ * Options for constructing a {@link JsonFileConfigLoader}.
+ */
+export type JsonFileConfigLoaderOptions<T> = {
+  /**
+   * The filename (or array of filenames) to search for.
+   * When an array is provided, the factory returns an {@link AggregateConfigProvider}.
+   */
+  filename: string | string[];
+  /**
+   * Optional transform applied when loading — extracts the desired config shape from the raw JSON.
+   */
+  transform?: (json: any) => T;
+  /**
+   * A function that merges the updated config back into the full JSON structure.
+   * Required for `updateConfig` when a read `transform` is used.
+   */
+  writeTransform?: (json: any, config: T) => any;
+};
+
+function loadJsonFile(filepath: string) {
+  const fs = getFileSystemProvider();
+  return JSON.parse(fs.readFileSync(filepath));
+}
+
+/**
+ * A configuration provider that loads configuration from a JSON file.
+ * Supports `file://` URLs for ESM-friendly usage.
+ */
+export class JsonFileConfigLoader<T>
+  implements ConfigurationProvider<T, string | URL>
+{
+  private readonly singleFilename: string;
+  private readonly transform?: (json: any) => T;
+  private readonly writeTransform?: (json: any, config: T) => any;
+
+  constructor(options: JsonFileConfigLoaderOptions<T>) {
+    if (Array.isArray(options.filename)) {
+      throw new Error(
+        'JsonFileConfigLoader does not accept an array of filenames. ' +
+          'Use getJsonFileConfigLoader() or pass a single filename.'
+      );
+    }
+    this.singleFilename = options.filename;
+    this.transform = options.transform;
+    this.writeTransform = options.writeTransform;
+  }
+
+  resolve(configurationRoot: string): string | undefined {
+    const nearestFile = traverseForFile(
+      this.singleFilename,
+      configurationRoot
+    );
+    if (nearestFile && nearestFile.endsWith('.json')) {
+      return nearestFile;
+    }
+    return undefined;
+  }
+
+  load(jsonFile: string | URL) {
+    const filePath = toFilePath(jsonFile);
+    const json = loadJsonFile(filePath);
+    if (this.transform) {
+      return this.transform(json) as T & { extends?: string };
+    }
+    return json as T & { extends?: string };
+  }
+
+  async updateConfig(
+    configOrUpdater: T | ((current: T) => T | Promise<T>),
+    options?: { targetPath?: string | URL }
+  ): Promise<void> {
+    if (this.transform && !this.writeTransform) {
+      throw new Error(
+        'Cannot update config when read transform is supplied without a write transform, doing so would set the untrasnformed file structure to the transformed structure, instead of updating it in place.'
+      );
+    }
+
+    const env = getEnvironmentProvider();
+    const fs = getFileSystemProvider();
+    const resolvedPath = options?.targetPath
+      ? toFilePath(options.targetPath)
+      : this.resolve(env.cwd());
+
+    if (!resolvedPath) {
+      throw new Error(
+        `Could not resolve configuration file "${this.singleFilename}" from ${env.cwd()}`
+      );
+    }
+
+    const fileExists = fs.existsSync(resolvedPath);
+
+    // When targetPath is provided and file doesn't exist, start from empty
+    const fullJson = fileExists ? loadJsonFile(resolvedPath) : {};
+    const currentConfig = this.transform ? this.transform(fullJson) : fullJson;
+
+    const newConfig =
+      typeof configOrUpdater === 'function'
+        ? await (configOrUpdater as (current: T) => T | Promise<T>)(
+            currentConfig
+          )
+        : configOrUpdater;
+
+    const outputJson =
+      this.writeTransform && this.transform
+        ? this.writeTransform(fullJson, newConfig)
+        : newConfig;
+
+    // Ensure parent directories exist when creating a new file
+    if (!fileExists) {
+      fs.mkdirSync(fs.dirname(resolvedPath), { recursive: true });
+    }
+
+    await fs.writeFile(resolvedPath, JSON.stringify(outputJson, null, 2) + '\n');
+  }
+
+  describeConfig(): ConfigurationDocSection {
+    const parts: string[] = [
+      `Searches for \`${this.singleFilename}\``,
+      'Resolution walks up the directory tree from the working directory, using the nearest match.',
+    ];
+    if (this.transform) {
+      parts.push(
+        'A transform is applied to extract configuration from the file.'
+      );
+    }
+    parts.push('Supports `"extends"` for configuration inheritance.');
+    return {
+      heading: `JSON File: ${this.singleFilename}`,
+      body: parts.join('\n\n'),
+    };
+  }
+
+  [inspect.custom]() {
+    return 'JsonFileConfigLoader: ' + this.singleFilename;
+  }
+}
 
 /**
  * A factory function to create simple configuration providers that load configuration from a JSON file.
@@ -42,94 +185,16 @@ export function getJsonFileConfigLoader<T>(
   writeTransform?: (json: any, config: T) => any
 ): AnyConfigProvider<T> {
   if (Array.isArray(filename)) {
-    const providers = filename.map((f) =>
-      getJsonFileConfigLoader(f, transform, writeTransform)
+    const providers = filename.map(
+      (f) =>
+        new JsonFileConfigLoader<T>({ filename: f, transform, writeTransform })
     );
     return new AggregateConfigProvider(providers);
   }
 
-  const singleFilename: string = filename;
-
-  function loadJsonFile(filepath: string) {
-    const fs = getFileSystemProvider();
-    return JSON.parse(fs.readFileSync(filepath));
-  }
-
-  class JsonFileConfigLoader {
-    resolve(configurationRoot: string) {
-      const nearestFile = traverseForFile(singleFilename, configurationRoot);
-      if (nearestFile && nearestFile.endsWith('.json')) {
-        return nearestFile;
-      }
-      return undefined;
-    }
-
-    load(jsonFile: string) {
-      const json = loadJsonFile(jsonFile);
-      if (transform) {
-        return transform(json);
-      }
-      return json;
-    }
-
-    async updateConfig(
-      configOrUpdater: T | ((current: T) => T | Promise<T>)
-    ): Promise<void> {
-      if (transform && !writeTransform) {
-        throw new Error(
-          'Cannot update config when read transform is supplied without a write transform, doing so would set the untrasnformed file structure to the transformed structure, instead of updating it in place.'
-        );
-      }
-
-      const env = getEnvironmentProvider();
-      const fs = getFileSystemProvider();
-
-      const resolvedPath = this.resolve(env.cwd());
-      if (!resolvedPath) {
-        throw new Error(
-          `Could not resolve configuration file "${singleFilename}" from ${env.cwd()}`
-        );
-      }
-
-      const fullJson = loadJsonFile(resolvedPath);
-      const currentConfig = transform ? transform(fullJson) : fullJson;
-
-      const newConfig =
-        typeof configOrUpdater === 'function'
-          ? await (configOrUpdater as (current: T) => T | Promise<T>)(
-              currentConfig
-            )
-          : configOrUpdater;
-
-      const outputJson =
-        writeTransform && transform
-          ? writeTransform(fullJson, newConfig)
-          : newConfig;
-
-      await fs.writeFile(resolvedPath, JSON.stringify(outputJson, null, 2) + '\n');
-    }
-
-    describeConfig(): ConfigurationDocSection {
-      const parts: string[] = [
-        `Searches for \`${singleFilename}\``,
-        'Resolution walks up the directory tree from the working directory, using the nearest match.',
-      ];
-      if (transform) {
-        parts.push(
-          'A transform is applied to extract configuration from the file.'
-        );
-      }
-      parts.push('Supports `"extends"` for configuration inheritance.');
-      return {
-        heading: `JSON File: ${singleFilename}`,
-        body: parts.join('\n\n'),
-      };
-    }
-
-    [Symbol.for('nodejs.util.inspect.custom')]() {
-      return 'JsonFileConfigLoader: ' + singleFilename;
-    }
-  }
-
-  return new JsonFileConfigLoader();
+  return new JsonFileConfigLoader<T>({
+    filename,
+    transform,
+    writeTransform,
+  });
 }

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -1,5 +1,3 @@
-import { inspect } from 'node:util';
-
 import {
   getEnvironmentProvider,
   getFileSystemProvider,
@@ -15,15 +13,13 @@ import {
 import { toFilePath, traverseForFile } from './utils.js';
 
 /**
- * Options for constructing a {@link JsonFileConfigLoader}.
+ * Options for constructing a single-file {@link JsonFileConfigLoader}.
  */
-export type JsonFileConfigLoaderOptions<T> = {
+export type JsonFileConfigLoaderSingleOptions<T> = {
   /**
-   * The filename (or array of filenames) to search for.
-   * When multiple filenames are provided, `resolve` tries each in order
-   * and returns the first match found while walking up the directory tree.
+   * The filename to search for.
    */
-  filename: string | string[];
+  filename: string;
   /**
    * Optional transform applied when loading — extracts the desired config shape from the raw JSON.
    */
@@ -35,36 +31,56 @@ export type JsonFileConfigLoaderOptions<T> = {
   writeTransform?: (json: any, config: T) => any;
 };
 
+/**
+ * Options for constructing multiple {@link JsonFileConfigLoader} providers at once.
+ */
+export type JsonFileConfigLoaderMultiOptions<T> = Omit<
+  JsonFileConfigLoaderSingleOptions<T>,
+  'filename'
+> & {
+  /**
+   * The filenames to search for.
+   * Each filename becomes its own provider so provenance and update routing stay per-file.
+   */
+  filename: string[];
+};
+
+/**
+ * Options for constructing one or more {@link JsonFileConfigLoader} providers.
+ */
+export type JsonFileConfigLoaderOptions<T> =
+  | JsonFileConfigLoaderSingleOptions<T>
+  | JsonFileConfigLoaderMultiOptions<T>;
+
+/**
+ * A single JSON file configuration provider instance.
+ */
+export interface JsonFileConfigLoader<T>
+  extends ConfigurationProvider<T, string | URL> {}
+
 function loadJsonFile(filepath: string) {
   const fs = getFileSystemProvider();
   return JSON.parse(fs.readFileSync(filepath));
 }
 
-/**
- * A configuration provider that loads configuration from a JSON file.
- * Supports multiple candidate filenames and `file://` URLs.
- */
-export class JsonFileConfigLoader<T>
-  implements ConfigurationProvider<T, string | URL>
-{
-  private readonly filenames: string[];
+class JsonFileConfigLoaderInstance<T> implements JsonFileConfigLoader<T> {
+  private readonly singleFilename: string;
   private readonly transform?: (json: any) => T;
   private readonly writeTransform?: (json: any, config: T) => any;
 
-  constructor(options: JsonFileConfigLoaderOptions<T>) {
-    this.filenames = Array.isArray(options.filename)
-      ? options.filename
-      : [options.filename];
+  constructor(options: JsonFileConfigLoaderSingleOptions<T>) {
+    this.singleFilename = options.filename;
     this.transform = options.transform;
     this.writeTransform = options.writeTransform;
   }
 
   resolve(configurationRoot: string): string | undefined {
-    for (const filename of this.filenames) {
-      const nearestFile = traverseForFile(filename, configurationRoot);
-      if (nearestFile && nearestFile.endsWith('.json')) {
-        return nearestFile;
-      }
+    const nearestFile = traverseForFile(
+      this.singleFilename,
+      configurationRoot
+    );
+    if (nearestFile && nearestFile.endsWith('.json')) {
+      return nearestFile;
     }
     return undefined;
   }
@@ -82,13 +98,14 @@ export class JsonFileConfigLoader<T>
     configOrUpdater: T | ((current: T) => T | Promise<T>),
     options?: { targetPath?: string | URL }
   ): Promise<void> {
+    const env = getEnvironmentProvider();
+
     if (this.transform && !this.writeTransform) {
       throw new Error(
         'Cannot update config when read transform is supplied without a write transform, doing so would set the untransformed file structure to the transformed structure, instead of updating it in place.'
       );
     }
 
-    const env = getEnvironmentProvider();
     const fs = getFileSystemProvider();
     const resolvedPath = options?.targetPath
       ? toFilePath(options.targetPath)
@@ -96,7 +113,7 @@ export class JsonFileConfigLoader<T>
 
     if (!resolvedPath) {
       throw new Error(
-        `Could not resolve configuration file "${this.filenames.join(', ')}" from ${env.cwd()}`
+        `Could not resolve configuration file "${this.singleFilename}" from ${env.cwd()}`
       );
     }
 
@@ -127,17 +144,10 @@ export class JsonFileConfigLoader<T>
   }
 
   describeConfig(): ConfigurationDocSection {
-    const filenameDisplay =
-      this.filenames.length === 1
-        ? `\`${this.filenames[0]}\``
-        : this.filenames.map((f) => `\`${f}\``).join(', ');
     const parts: string[] = [
-      `Searches for ${filenameDisplay}`,
+      `Searches for \`${this.singleFilename}\``,
       'Resolution walks up the directory tree from the working directory, using the nearest match.',
     ];
-    if (this.filenames.length > 1) {
-      parts.push('Filenames are tried in order; the first match wins.');
-    }
     if (this.transform) {
       parts.push(
         'A transform is applied to extract configuration from the file.'
@@ -145,15 +155,42 @@ export class JsonFileConfigLoader<T>
     }
     parts.push('Supports `"extends"` for configuration inheritance.');
     return {
-      heading: `JSON File: ${this.filenames.join(', ')}`,
+      heading: `JSON File: ${this.singleFilename}`,
       body: parts.join('\n\n'),
     };
   }
-
-  [inspect.custom]() {
-    return 'JsonFileConfigLoader: ' + this.filenames.join(', ');
-  }
 }
+
+type JsonFileConfigLoaderConstructor = {
+  new <T>(
+    options: JsonFileConfigLoaderSingleOptions<T>
+  ): JsonFileConfigLoader<T>;
+  new <T>(
+    options: JsonFileConfigLoaderMultiOptions<T>
+  ): JsonFileConfigLoader<T>[];
+};
+
+/**
+ * A configuration provider constructor for JSON-backed config.
+ * With a single filename it returns one provider; with multiple filenames it returns multiple providers.
+ */
+export const JsonFileConfigLoader: JsonFileConfigLoaderConstructor =
+  class JsonFileConfigLoader<T> {
+    constructor(options: JsonFileConfigLoaderOptions<T>) {
+      if (Array.isArray(options.filename)) {
+        return options.filename.map(
+          (filename) =>
+            new JsonFileConfigLoaderInstance<T>({
+              ...options,
+              filename,
+            })
+        );
+      }
+      return new JsonFileConfigLoaderInstance<T>(
+        options as JsonFileConfigLoaderSingleOptions<T>
+      );
+    }
+  } as unknown as JsonFileConfigLoaderConstructor;
 
 /**
  * A factory function to create simple configuration providers that load configuration from a JSON file.

--- a/packages/parser/src/lib/config-files/json-file-loader.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.ts
@@ -88,7 +88,7 @@ export class JsonFileConfigLoader<T>
   ): Promise<void> {
     if (this.transform && !this.writeTransform) {
       throw new Error(
-        'Cannot update config when read transform is supplied without a write transform, doing so would set the untrasnformed file structure to the transformed structure, instead of updating it in place.'
+        'Cannot update config when read transform is supplied without a write transform, doing so would set the untransformed file structure to the transformed structure, instead of updating it in place.'
       );
     }
 

--- a/packages/parser/src/lib/config-files/package-json-loader.ts
+++ b/packages/parser/src/lib/config-files/package-json-loader.ts
@@ -1,10 +1,7 @@
 import { inspect } from 'node:util';
 
 import { ConfigurationProvider } from './configuration-loader.js';
-import {
-  getJsonFileConfigLoader,
-  JsonFileConfigLoader,
-} from './json-file-loader.js';
+import { JsonFileConfigLoader } from './json-file-loader.js';
 
 /**
  * Options for constructing a {@link PackageJsonConfigLoader}.

--- a/packages/parser/src/lib/config-files/package-json-loader.ts
+++ b/packages/parser/src/lib/config-files/package-json-loader.ts
@@ -1,5 +1,3 @@
-import { inspect } from 'node:util';
-
 import { ConfigurationProvider } from './configuration-loader.js';
 import { JsonFileConfigLoader } from './json-file-loader.js';
 
@@ -44,7 +42,7 @@ export class PackageJsonConfigLoader<T>
     configOrUpdater: T | ((current: T) => T | Promise<T>),
     options?: { targetPath?: string | URL }
   ) {
-    return this.inner.updateConfig(configOrUpdater, options);
+    return this.inner.updateConfig!(configOrUpdater, options);
   }
 
   describeConfig() {
@@ -60,10 +58,6 @@ export class PackageJsonConfigLoader<T>
         '```',
       ].join('\n'),
     };
-  }
-
-  [inspect.custom]() {
-    return 'PackageJsonConfigurationLoader: ' + this.key;
   }
 }
 

--- a/packages/parser/src/lib/config-files/package-json-loader.ts
+++ b/packages/parser/src/lib/config-files/package-json-loader.ts
@@ -1,5 +1,74 @@
+import { inspect } from 'node:util';
+
 import { ConfigurationProvider } from './configuration-loader.js';
-import { getJsonFileConfigLoader } from './json-file-loader.js';
+import {
+  getJsonFileConfigLoader,
+  JsonFileConfigLoader,
+} from './json-file-loader.js';
+
+/**
+ * Options for constructing a {@link PackageJsonConfigLoader}.
+ */
+export type PackageJsonConfigLoaderOptions = {
+  /**
+   * The key in the package.json file to load as configuration.
+   */
+  key: string;
+};
+
+/**
+ * A configuration provider that loads configuration from a key in a `package.json` file.
+ * Internally delegates to a {@link JsonFileConfigLoader} with appropriate transforms.
+ */
+export class PackageJsonConfigLoader<T>
+  implements ConfigurationProvider<T, string | URL>
+{
+  private readonly inner: JsonFileConfigLoader<T>;
+  private readonly key: string;
+
+  constructor(options: PackageJsonConfigLoaderOptions) {
+    this.key = options.key;
+    this.inner = new JsonFileConfigLoader<T>({
+      filename: 'package.json',
+      transform: (json) => json[this.key],
+      writeTransform: (json, config) => ({ ...json, [this.key]: config }),
+    });
+  }
+
+  resolve(configurationRoot: string) {
+    return this.inner.resolve(configurationRoot);
+  }
+
+  load(filename: string | URL) {
+    return this.inner.load(filename);
+  }
+
+  async updateConfig(
+    configOrUpdater: T | ((current: T) => T | Promise<T>),
+    options?: { targetPath?: string | URL }
+  ) {
+    return this.inner.updateConfig(configOrUpdater, options);
+  }
+
+  describeConfig() {
+    return {
+      heading: `package.json (key: "${this.key}")`,
+      body: [
+        `Reads the \`"${this.key}"\` key from the nearest \`package.json\` file.`,
+        'Resolution walks up the directory tree from the working directory.',
+        '',
+        '**Example:**',
+        '```json',
+        JSON.stringify({ [this.key]: { option: 'value' } }, null, 2),
+        '```',
+      ].join('\n'),
+    };
+  }
+
+  [inspect.custom]() {
+    return 'PackageJsonConfigurationLoader: ' + this.key;
+  }
+}
 
 /**
  * A factory function to create a configuration provider that loads configuration from a package.json file.
@@ -9,24 +78,5 @@ import { getJsonFileConfigLoader } from './json-file-loader.js';
 export function getPackageJsonConfigurationLoader<T>(
   key: string
 ): ConfigurationProvider<T> {
-  const loader = getJsonFileConfigLoader<T>(
-    'package.json',
-    (json) => json[key],
-    (json, config) => ({ ...json, [key]: config })
-  );
-  (loader as any)[Symbol.for('nodejs.util.inspect.custom')] = () =>
-    'PackageJsonConfigurationLoader: ' + key;
-  loader.describeConfig = () => ({
-    heading: `package.json (key: "${key}")`,
-    body: [
-      `Reads the \`"${key}"\` key from the nearest \`package.json\` file.`,
-      'Resolution walks up the directory tree from the working directory.',
-      '',
-      '**Example:**',
-      '```json',
-      JSON.stringify({ [key]: { option: 'value' } }, null, 2),
-      '```',
-    ].join('\n'),
-  });
-  return loader;
+  return new PackageJsonConfigLoader<T>({ key });
 }

--- a/packages/parser/src/lib/config-files/utils.ts
+++ b/packages/parser/src/lib/config-files/utils.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { getFileSystemProvider } from '../environment-provider';
 
 export function traverseForFile(
@@ -18,4 +20,13 @@ export function traverseForFile(
     }
   }
   return undefined;
+}
+
+/**
+ * Normalizes a string or URL to a file system path string.
+ * If given a URL, converts it via `fileURLToPath` (only `file://` URLs are supported).
+ * If given a string, returns it as-is.
+ */
+export function toFilePath(pathOrUrl: string | URL): string {
+  return pathOrUrl instanceof URL ? fileURLToPath(pathOrUrl) : pathOrUrl;
 }

--- a/packages/parser/src/lib/config-files/utils.ts
+++ b/packages/parser/src/lib/config-files/utils.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath } from 'node:url';
-
 import { getFileSystemProvider } from '../environment-provider';
 
 export function traverseForFile(
@@ -24,9 +22,31 @@ export function traverseForFile(
 
 /**
  * Normalizes a string or URL to a file system path string.
- * If given a URL, converts it via `fileURLToPath` (only `file://` URLs are supported).
+ * If given a file URL, converts it without depending on Node-only modules.
  * If given a string, returns it as-is.
  */
 export function toFilePath(pathOrUrl: string | URL): string {
-  return pathOrUrl instanceof URL ? fileURLToPath(pathOrUrl) : pathOrUrl;
+  if (!(pathOrUrl instanceof URL)) {
+    return pathOrUrl;
+  }
+
+  if (pathOrUrl.protocol !== 'file:') {
+    throw new Error(
+      `Unsupported URL protocol "${pathOrUrl.protocol}" for configuration file path.`
+    );
+  }
+
+  let pathname = decodeURIComponent(pathOrUrl.pathname);
+
+  // Normalize Windows file URLs like file:///C:/path/to/file.json.
+  if (/^\/[A-Za-z]:/.test(pathname)) {
+    pathname = pathname.slice(1);
+  }
+
+  // Preserve UNC-style file URLs like file://server/share/config.json.
+  if (pathOrUrl.host) {
+    return `//${pathOrUrl.host}${pathname}`;
+  }
+
+  return pathname;
 }

--- a/packages/parser/src/lib/parser.spec.ts
+++ b/packages/parser/src/lib/parser.spec.ts
@@ -1373,6 +1373,200 @@ describe('parser', () => {
   });
 });
 
+describe('parser.updateConfig', () => {
+  function makeUpdatableProvider() {
+    const writes: any[] = [];
+    let current: Record<string, any> = {};
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => '/root/.config.json',
+      load: () => current,
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)(current)
+            : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+        current = next;
+      },
+    };
+    return { provider, writes, getCurrent: () => current };
+  }
+
+  it('should route partial updates to the owning provider before parse runs', async () => {
+    const { provider, writes } = makeUpdatableProvider();
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .option('bar', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig({ foo: 'hello', bar: 7 });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ foo: 'hello', bar: 7 });
+  });
+
+  it('should reflect updated values when parsing after updateConfig', async () => {
+    const { provider } = makeUpdatableProvider();
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .option('bar', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig({ foo: 'hello', bar: 7 });
+
+    expect(p.parse([])).toEqual({ foo: 'hello', bar: 7, unmatched: [] });
+  });
+
+  it('should fall through to the default target path when no provider resolves', async () => {
+    const writes: any[] = [];
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function' ? await (updater as any)({}) : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+      },
+    };
+
+    class JsonLoader {
+      constructor(_opts: { filename: string }) {
+        return provider;
+      }
+    }
+
+    const p = parser()
+      .option('theme', { type: 'string' })
+      .option('lang', { type: 'string' })
+      .config(JsonLoader as any, {
+        filename: 'my-tool.config.json',
+        default: '/new/home/my-tool.config.json',
+      });
+
+    await p.updateConfig({ theme: 'dark', lang: 'fr' });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ theme: 'dark', lang: 'fr' });
+    expect(writes[0].targetPath).toBe('/new/home/my-tool.config.json');
+  });
+
+  it('should support lazy default functions returning a target path', async () => {
+    const writes: any[] = [];
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (_updater, options) => {
+        writes.push(options?.targetPath);
+      },
+    };
+
+    class JsonLoader {
+      constructor(_opts: { filename: string }) {
+        return provider;
+      }
+    }
+
+    let callCount = 0;
+    const p = parser()
+      .option('key', { type: 'string' })
+      .config(JsonLoader as any, {
+        filename: 'my.json',
+        default: () => {
+          callCount++;
+          return '/fresh/my.json';
+        },
+      });
+
+    await p.updateConfig({ key: 'value' });
+
+    expect(callCount).toBe(1);
+    expect(writes).toEqual(['/fresh/my.json']);
+  });
+
+  it('should throw a descriptive error when no provider resolves and no default is configured', async () => {
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async () => {},
+    };
+
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .config(provider);
+
+    await expect(p.updateConfig({ foo: 'bar' })).rejects.toThrow(
+      /no provider resolved/
+    );
+  });
+
+  it('should route each key to its owning provider across multiple providers', async () => {
+    const writesA: any[] = [];
+    const writesB: any[] = [];
+    const providerA: ConfigurationProvider<any> = {
+      resolve: () => '/root/.a',
+      load: () => ({ alpha: 'a-value' }),
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)({ alpha: 'a-value' })
+            : updater;
+        writesA.push(next);
+      },
+    };
+    const providerB: ConfigurationProvider<any> = {
+      resolve: () => '/root/.b',
+      load: () => ({ beta: 'b-value' }),
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)({ beta: 'b-value' })
+            : updater;
+        writesB.push(next);
+      },
+    };
+
+    const p = parser()
+      .option('alpha', { type: 'string' })
+      .option('beta', { type: 'string' })
+      .config([providerA, providerB]);
+
+    await p.updateConfig({ alpha: 'A2', beta: 'B2' });
+
+    expect(writesA).toEqual([{ alpha: 'A2' }]);
+    expect(writesB).toEqual([{ beta: 'B2' }]);
+  });
+
+  it('should support updater function via proxy tracking', async () => {
+    const writes: any[] = [];
+    let current: Record<string, any> = { alpha: 'orig', count: 5 };
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => '/root/.config',
+      load: () => current,
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)(current)
+            : updater;
+        writes.push(next);
+        current = next;
+      },
+    };
+
+    const p = parser()
+      .option('alpha', { type: 'string' })
+      .option('count', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig((config) => {
+      config.count = (config as any).count + 1;
+    });
+
+    expect(writes).toHaveLength(1);
+    // Only `count` was set, `alpha` should be untouched from the original
+    expect(writes[0]).toEqual({ alpha: 'orig', count: 6 });
+  });
+});
+
 
 describe('oneOf options', () => {
   it('should parse string value for oneOf [string, boolean]', () => {

--- a/packages/parser/src/lib/parser.spec.ts
+++ b/packages/parser/src/lib/parser.spec.ts
@@ -1371,6 +1371,35 @@ describe('parser', () => {
         .parse([])
     ).toEqual({ foo: 'hello', bar: 42, unmatched: [] });
   });
+
+  it('should accept a pre-built provider with `default` metadata via the (provider, options) overload', async () => {
+    const writes: Array<{ next: any; targetPath?: string | URL }> = [];
+    const provider: ConfigurationProvider<any> = {
+      // Never resolves from cwd — forces the default fallback path.
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function' ? await (updater as any)({}) : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+      },
+    };
+
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .config(provider, { default: '/new/home/config.json' });
+
+    // Still parses successfully (no provider resolved, no values).
+    expect(p.parse([])).toEqual({ unmatched: [] });
+
+    // updateConfig falls through to the default path attached via the
+    // new overload.
+    await p.updateConfig({ foo: 'hello' });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ foo: 'hello' });
+    expect(writes[0].targetPath).toBe('/new/home/config.json');
+  });
 });
 
 describe('parser.updateConfig', () => {

--- a/packages/parser/src/lib/parser.spec.ts
+++ b/packages/parser/src/lib/parser.spec.ts
@@ -1327,6 +1327,50 @@ describe('parser', () => {
         .parse([])
     ).toEqual({ foo: 'fromA', bar: 2, unmatched: [] });
   });
+
+  it('should support registering multiple providers as an array', () => {
+    const providerA: ConfigurationProvider<any> = {
+      resolve: (dir) => join(dir, '.configA'),
+      load: () => ({ foo: 'fromA' }),
+    };
+    const providerB: ConfigurationProvider<any> = {
+      resolve: (dir) => join(dir, '.configB'),
+      load: () => ({ bar: 2 }),
+    };
+
+    expect(
+      parser()
+        .option('foo', { type: 'string' })
+        .option('bar', { type: 'number' })
+        .config([providerA, providerB])
+        .parse([])
+    ).toEqual({ foo: 'fromA', bar: 2, unmatched: [] });
+  });
+
+  it('should support constructors that register multiple providers', () => {
+    class LoaderPair {
+      constructor(options: { foo: string; bar: number }) {
+        return [
+          {
+            resolve: () => 'a',
+            load: () => ({ foo: options.foo }),
+          },
+          {
+            resolve: () => 'b',
+            load: () => ({ bar: options.bar }),
+          },
+        ] as ConfigurationProvider<any>[];
+      }
+    }
+
+    expect(
+      parser()
+        .option('foo', { type: 'string' })
+        .option('bar', { type: 'number' })
+        .config(LoaderPair, { foo: 'hello', bar: 42 })
+        .parse([])
+    ).toEqual({ foo: 'hello', bar: 42, unmatched: [] });
+  });
 });
 
 

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -1,10 +1,14 @@
 import {
   ConfigurationDocSection,
+  ConfigurationProvider,
+  DefaultConfig,
+  ExtractLocation,
 } from './config-files/configuration-loader';
 import {
   AggregateConfigProvider,
   AnyConfigProvider,
   ConfigUpdater,
+  ProviderEntry,
   isAggregateConfigProvider,
 } from './config-files/aggregate-config-provider';
 import { hideBin } from './helpers';
@@ -207,7 +211,7 @@ export class ArgvParser<
    */
   parserMap: Record<string, Parser<any>>;
 
-  private configuredConfigurationProviders: AnyConfigProvider<TArgs>[] = [];
+  private configuredConfigurationProviders: ProviderEntry<TArgs>[] = [];
 
   /**
    * If set, options can be populated from environment variables of the form `${envPrefix}_${optionName}`.
@@ -548,8 +552,43 @@ export class ArgvParser<
    * Registers a configuration provider to read configuration from.
    * @param provider The configuration provider to register.
    */
-  config(provider: AnyConfigProvider<TArgs>) {
-    this.configuredConfigurationProviders.push(provider);
+  config(provider: AnyConfigProvider<TArgs>): this;
+  /**
+   * Registers a configuration provider by class and options.
+   * Framework options like `default` are extracted and stored as metadata.
+   *
+   * @param ctor The provider class constructor.
+   * @param options Constructor options merged with framework options (e.g., `default`).
+   */
+  config<
+    C extends new (opts: any) => ConfigurationProvider<TArgs, any>,
+  >(
+    ctor: C,
+    options: ConstructorParameters<C>[0] & {
+      default?: DefaultConfig<ExtractLocation<InstanceType<C>>>;
+    }
+  ): this;
+  config<
+    C extends new (opts: any) => ConfigurationProvider<TArgs, any>,
+  >(
+    providerOrCtor: AnyConfigProvider<TArgs> | C,
+    options?: ConstructorParameters<C>[0] & {
+      default?: DefaultConfig<ExtractLocation<InstanceType<C>>>;
+    }
+  ): this {
+    if (options !== undefined) {
+      // Constructor-based overload: extract framework opts, construct provider
+      const { default: defaultConfig, ...providerOpts } = options;
+      const provider = new (providerOrCtor as C)(providerOpts);
+      this.configuredConfigurationProviders.push({
+        provider: provider as unknown as AnyConfigProvider<TArgs>,
+        default: defaultConfig,
+      });
+    } else {
+      this.configuredConfigurationProviders.push({
+        provider: providerOrCtor as AnyConfigProvider<TArgs>,
+      });
+    }
     return this;
   }
 
@@ -1099,7 +1138,8 @@ export class ArgvParser<
    */
   getConfigurationDocs(): ConfigurationDocSection[] {
     const sections: ConfigurationDocSection[] = [];
-    for (const provider of this.configuredConfigurationProviders) {
+    for (const entry of this.configuredConfigurationProviders) {
+      const provider = entry.provider;
       if (isAggregateConfigProvider(provider)) {
         sections.push(...provider.describeConfig());
       } else if (provider.describeConfig) {

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -576,17 +576,23 @@ export class ArgvParser<
       default?: DefaultConfig<ExtractLocation<InstanceType<C>>>;
     }
   ): this {
-    if (options !== undefined) {
+    if (typeof providerOrCtor === 'function') {
+      if (options === undefined) {
+        throw new TypeError(
+          'ArgvParser.config() requires `options` when registering a configuration provider by constructor.'
+        );
+      }
+
       // Constructor-based overload: extract framework opts, construct provider
       const { default: defaultConfig, ...providerOpts } = options;
-      const provider = new (providerOrCtor as C)(providerOpts);
+      const provider = new providerOrCtor(providerOpts);
       this.configuredConfigurationProviders.push({
         provider: provider as unknown as AnyConfigProvider<TArgs>,
         default: defaultConfig,
       });
     } else {
       this.configuredConfigurationProviders.push({
-        provider: providerOrCtor as AnyConfigProvider<TArgs>,
+        provider: providerOrCtor,
       });
     }
     return this;

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -559,6 +559,19 @@ export class ArgvParser<
    */
   config(provider: ConfigProviderRegistration<TArgs>): this;
   /**
+   * Registers a pre-built configuration provider with framework-level
+   * metadata such as `default`. Use this overload with convenience
+   * factories like {@link ConfigurationProviders.JsonFile} that return a
+   * fully-constructed provider but still need to carry a `default` path.
+   *
+   * @param provider The configuration provider to register.
+   * @param options Framework-level options (e.g. `default`).
+   */
+  config<R extends ConfigProviderRegistration<TArgs>>(
+    provider: R,
+    options: { default?: DefaultConfig<RegistrationLocation<R>> }
+  ): this;
+  /**
    * Registers a configuration provider by class and options.
    * Framework options like `default` are extracted and stored as metadata.
    *
@@ -577,9 +590,11 @@ export class ArgvParser<
     C extends new (opts: any) => ConfigProviderRegistration<TArgs>,
   >(
     providerOrCtor: ConfigProviderRegistration<TArgs> | C,
-    options?: ConstructorParameters<C>[0] & {
-      default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
-    }
+    options?:
+      | { default?: DefaultConfig<any> }
+      | (ConstructorParameters<C>[0] & {
+          default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
+        })
   ): this {
     if (typeof providerOrCtor === 'function') {
       if (options === undefined) {
@@ -589,10 +604,15 @@ export class ArgvParser<
       }
 
       // Constructor-based overload: extract framework opts, construct provider
-      const { default: defaultConfig, ...providerOpts } = options;
+      const { default: defaultConfig, ...providerOpts } = options as any;
       const provider = new providerOrCtor(providerOpts);
       this.registerConfigurationProviders(provider, {
         default: defaultConfig,
+      });
+    } else if (options !== undefined) {
+      // Pre-built provider with framework metadata
+      this.registerConfigurationProviders(providerOrCtor, {
+        default: (options as { default?: DefaultConfig<any> }).default,
       });
     } else {
       this.registerConfigurationProviders(providerOrCtor);

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -7,6 +7,7 @@ import {
 import {
   AggregateConfigProvider,
   AnyConfigProvider,
+  ConfigProviderRegistration,
   ConfigUpdater,
   ProviderEntry,
   isAggregateConfigProvider,
@@ -64,6 +65,10 @@ export type EnvOptionConfig = {
   reflect?: boolean;
   populate?: boolean;
 };
+
+type RegistrationLocation<R> = R extends readonly (infer P)[]
+  ? ExtractLocation<P>
+  : ExtractLocation<R>;
 
 /**
  * Base type for parsed arguments.
@@ -552,7 +557,7 @@ export class ArgvParser<
    * Registers a configuration provider to read configuration from.
    * @param provider The configuration provider to register.
    */
-  config(provider: AnyConfigProvider<TArgs>): this;
+  config(provider: ConfigProviderRegistration<TArgs>): this;
   /**
    * Registers a configuration provider by class and options.
    * Framework options like `default` are extracted and stored as metadata.
@@ -561,19 +566,19 @@ export class ArgvParser<
    * @param options Constructor options merged with framework options (e.g., `default`).
    */
   config<
-    C extends new (opts: any) => ConfigurationProvider<TArgs, any>,
+    C extends new (opts: any) => ConfigProviderRegistration<TArgs>,
   >(
     ctor: C,
     options: ConstructorParameters<C>[0] & {
-      default?: DefaultConfig<ExtractLocation<InstanceType<C>>>;
+      default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
     }
   ): this;
   config<
-    C extends new (opts: any) => ConfigurationProvider<TArgs, any>,
+    C extends new (opts: any) => ConfigProviderRegistration<TArgs>,
   >(
-    providerOrCtor: AnyConfigProvider<TArgs> | C,
+    providerOrCtor: ConfigProviderRegistration<TArgs> | C,
     options?: ConstructorParameters<C>[0] & {
-      default?: DefaultConfig<ExtractLocation<InstanceType<C>>>;
+      default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
     }
   ): this {
     if (typeof providerOrCtor === 'function') {
@@ -586,16 +591,27 @@ export class ArgvParser<
       // Constructor-based overload: extract framework opts, construct provider
       const { default: defaultConfig, ...providerOpts } = options;
       const provider = new providerOrCtor(providerOpts);
-      this.configuredConfigurationProviders.push({
-        provider: provider as unknown as AnyConfigProvider<TArgs>,
+      this.registerConfigurationProviders(provider, {
         default: defaultConfig,
       });
     } else {
-      this.configuredConfigurationProviders.push({
-        provider: providerOrCtor,
-      });
+      this.registerConfigurationProviders(providerOrCtor);
     }
     return this;
+  }
+
+  private registerConfigurationProviders(
+    providers: ConfigProviderRegistration<TArgs>,
+    metadata?: { default?: DefaultConfig<any> }
+  ) {
+    const registrations = Array.isArray(providers) ? providers : [providers];
+    for (let i = 0; i < registrations.length; i++) {
+      this.configuredConfigurationProviders.push(
+        i === 0 && metadata
+          ? { provider: registrations[i], ...metadata }
+          : { provider: registrations[i] }
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Add framework-level `default` option for config providers that specifies
where to create config files when none exist on disk. This enables
`updateConfig` to work without pre-existing files (e.g., for `init` commands).

Key changes:
- Add `TLocation` generic to `ConfigurationProvider` for URL support
- Add `targetPath` option to `updateConfig` for framework-directed writes
- Refactor `JsonFileConfigLoader` and `PackageJsonConfigLoader` to exported
  classes with single-object constructors
- Add `.config(Class, opts)` overload that extracts `default` as metadata
- Aggregate resolves `default` with null-fallthrough support
- Add `toFilePath` helper for `string | URL` normalization

https://claude.ai/code/session_01VAaP3rAbSbRvhvavmsd4DN