### PR TITLE
fix(repo): prevent scripts package from being published by nx release

### DIFF
--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cli-forge-scripts",
+  "private": true,
   "exports": {
     "./*": {
       "import": "./*.ts",

--- a/tools/scripts/project.json
+++ b/tools/scripts/project.json
@@ -1,8 +1,0 @@
-{
-  "name": "cli-forge-scripts",
-  "targets": {
-    "nx-release-publish": {
-      "executor": "nx:noop"
-    }
-  }
-}

--- a/tools/scripts/project.json
+++ b/tools/scripts/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "cli-forge-scripts",
+  "targets": {
+    "nx-release-publish": {
+      "executor": "nx:noop"
+    }
+  }
+}


### PR DESCRIPTION
Add a project.json to tools/scripts with nx-release-publish set to
nx:noop so that dependent publish targets don't attempt to publish
the internal scripts package.

https://claude.ai/code/session_01LT3WpEcNn2Zcgev9X9EGBP