### PR TITLE
fix(docs-site): patch rehype-typedoc to disambiguate colliding slugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "cli-forge": "workspace:*"
     },
     "patchedDependencies": {
-      "vike-plugin-typedoc@0.2.0": "patches/vike-plugin-typedoc@0.2.0.patch"
+      "vike-plugin-typedoc@0.2.0": "patches/vike-plugin-typedoc@0.2.0.patch",
+      "rehype-typedoc@0.2.0": "patches/rehype-typedoc@0.2.0.patch"
     }
   },
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"

--- a/patches/rehype-typedoc@0.2.0.patch
+++ b/patches/rehype-typedoc@0.2.0.patch
@@ -1,0 +1,101 @@
+diff --git a/dist/build-symbols.js b/dist/build-symbols.js
+index fb1b3ff14ae48b7d8a88d88cbb3daa9d8c491d9a..3f36670ccb023b006dd166172db1a0f7e9fcbb7c 100644
+--- a/dist/build-symbols.js
++++ b/dist/build-symbols.js
+@@ -68,6 +68,8 @@ export function buildSymbolsFromDocuments(documents, buildUrl) {
+     const logger = new ConsoleLogger();
+     logger.level = LogLevel.None;
+     const deserializer = new Deserializer(logger);
++    // First pass: collect all symbols with their slugs (defer path computation)
++    const allSymbols = [];
+     for (const { packageSlug, json } of documents) {
+         const registry = new FileRegistry();
+         const project = deserializer.reviveProject(packageSlug, json, {
+@@ -88,33 +90,71 @@ export function buildSymbolsFromDocuments(documents, buildUrl) {
+                 const kind = kindToString(reflection.kind);
+                 if (!kind)
+                     continue;
+-                const symbolSlug = slugify(reflection.name);
+-                const path = buildUrl(packageSlug, symbolSlug);
+                 const reExport = isReExported(reflection, packageSlug);
+-                const sym = {
++                allSymbols.push({
+                     name: reflection.name,
+                     package: packageSlug,
+-                    path,
++                    slug: slugify(reflection.name),
+                     kind,
+                     ...(reExport ? { isReExport: true } : {}),
+-                };
+-                const existing = map.get(reflection.name);
+-                if (!existing) {
+-                    map.set(reflection.name, sym);
+-                }
+-                else if (Array.isArray(existing)) {
+-                    existing.push(sym);
+-                }
+-                else {
+-                    // Promote single entry to array
+-                    map.set(reflection.name, [existing, sym]);
+-                }
++                });
+             }
+         }
+         if (project.children) {
+             walkReflections(project.children);
+         }
+     }
++    // Second pass: disambiguate colliding slugs within each package
++    // by appending the kind suffix (matches vike-plugin-typedoc behavior)
++    const byPackage = new Map();
++    for (const sym of allSymbols) {
++        let pkgSymbols = byPackage.get(sym.package);
++        if (!pkgSymbols) {
++            pkgSymbols = [];
++            byPackage.set(sym.package, pkgSymbols);
++        }
++        pkgSymbols.push(sym);
++    }
++    for (const [, pkgSymbols] of byPackage) {
++        const slugGroups = new Map();
++        for (const sym of pkgSymbols) {
++            let group = slugGroups.get(sym.slug);
++            if (!group) {
++                group = [];
++                slugGroups.set(sym.slug, group);
++            }
++            group.push(sym);
++        }
++        for (const [, group] of slugGroups) {
++            if (group.length < 2)
++                continue;
++            for (const sym of group) {
++                sym.slug = `${sym.slug}-${sym.kind}`;
++            }
++        }
++    }
++    // Third pass: build paths with disambiguated slugs and populate the map
++    for (const sym of allSymbols) {
++        const path = buildUrl(sym.package, sym.slug);
++        const entry = {
++            name: sym.name,
++            package: sym.package,
++            path,
++            kind: sym.kind,
++            ...(sym.isReExport ? { isReExport: true } : {}),
++        };
++        const existing = map.get(sym.name);
++        if (!existing) {
++            map.set(sym.name, entry);
++        }
++        else if (Array.isArray(existing)) {
++            existing.push(entry);
++        }
++        else {
++            // Promote single entry to array
++            map.set(sym.name, [existing, entry]);
++        }
++    }
+     return map;
+ }
+ //# sourceMappingURL=build-symbols.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ overrides:
   cli-forge: workspace:*
 
 patchedDependencies:
+  rehype-typedoc@0.2.0:
+    hash: 9bbfc4ce3015d066529ed231b3ae85e688128dca41be8053f31d659cc50f241a
+    path: patches/rehype-typedoc@0.2.0.patch
   vike-plugin-typedoc@0.2.0:
     hash: d6d5a95a0ed6034598052d829318dc079cda8eb12244d9093896039272dfdd23
     path: patches/vike-plugin-typedoc@0.2.0.patch
@@ -334,7 +337,7 @@ importers:
         version: 10.0.1
       rehype-typedoc:
         specifier: ^0.2.0
-        version: 0.2.0(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5)
+        version: 0.2.0(patch_hash=9bbfc4ce3015d066529ed231b3ae85e688128dca41be8053f31d659cc50f241a)(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5)
       remark-directive:
         specifier: ^3.0.1
         version: 3.0.1
@@ -12926,7 +12929,7 @@ snapshots:
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 
-  rehype-typedoc@0.2.0(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5):
+  rehype-typedoc@0.2.0(patch_hash=9bbfc4ce3015d066529ed231b3ae85e688128dca41be8053f31d659cc50f241a)(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5):
     dependencies:
       remark-directive: 3.0.1
       typedoc: 0.28.18(typescript@5.9.3)
@@ -13777,7 +13780,7 @@ snapshots:
   vike-plugin-typedoc@0.2.0(patch_hash=d6d5a95a0ed6034598052d829318dc079cda8eb12244d9093896039272dfdd23)(react@19.2.4)(shiki@3.23.0)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(vike-react@0.6.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vike@0.4.256(react-streaming@0.4.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))))(vike@0.4.256(react-streaming@0.4.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       rehype-stringify: 10.0.1
-      rehype-typedoc: 0.2.0(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5)
+      rehype-typedoc: 0.2.0(patch_hash=9bbfc4ce3015d066529ed231b3ae85e688128dca41be8053f31d659cc50f241a)(remark-directive@3.0.1)(typedoc@0.28.18(typescript@5.9.3))(typescript@5.9.3)(unified@11.0.5)
       remark-breaks: 4.0.0
       remark-directive: 3.0.1
       remark-gfm: 4.0.1


### PR DESCRIPTION
rehype-typedoc's buildSymbolsFromDocuments uses slugify(name) to
generate URL slugs but doesn't handle collisions (e.g. CLI interface
and cli function both slugify to "cli"). vike-plugin-typedoc's
deserializer appends "-{kind}" for collisions, so pages live at
/api/cli-forge/cli-function and /api/cli-forge/cli-interface, but
rehype-typedoc links pointed to the non-existent /api/cli-forge/cli.

The patch adds per-package slug disambiguation to match
vike-plugin-typedoc's behavior.

https://claude.ai/code/session_011HBYBFG4XXtx6Jjv2gswQt