### PR TITLE
fix(cli-forge): flatten types in ComposableBuilder and ArgumentsOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,18 @@ CLI Forge is primarily developed against modern Node.js, and is also compatible 
 ## Key Features
 
 - **Full type inference** for parsed arguments based on your option definitions
-- **Flexible option types**: strings, numbers, booleans, arrays, and nested objects
+- **Flexible option types**: strings, numbers, booleans, arrays, nested objects, and [`oneOf` unions](https://craigory.dev/cli-forge/examples/one-of-option)
 - **Command hierarchy** with unlimited nesting and inherited options
-- **Middleware system** for transforming arguments before handler execution
+- **Composable builders** with [`chain()` and `makeComposableBuilder()`](https://craigory.dev/cli-forge/examples/composable-options) for reusable option groups
+- **Middleware system** for transforming arguments before handler execution, including [Zod schema validation](https://craigory.dev/cli-forge/docs/guides/middleware)
+- **Environment variable support** with [per-option or global env mapping](https://craigory.dev/cli-forge/examples/env-options)
 - **Interactive shell** (opt-in) for easier exploration of complex command trees
+- **Shell completions** for bash, zsh, fish, and PowerShell
 - **Automatic documentation generation** to markdown or JSON formats
 - **Configuration file support** with inheritance via `extends`
 - **Built-in test harness** for unit testing your CLI commands
 - **Comprehensive validation** with custom validators, choices, and cross-option constraints
+- **Browser support** via [browser-safe stubs](https://craigory.dev/cli-forge/docs/guides/browser-usage)
 
 ## Quick Start
 
@@ -74,43 +78,7 @@ cli('my-cli')
 
 ## Usage
 
-See docs for more examples: [https://craigory.dev/cli-forge/examples](https://craigory.dev/cli-forge/examples)
-
-### Basic Example
-
-To create a new CLI, save the below code to a file (e.g. `my-cli.js`), and run it with Node.js:
-
-```js
-import { cli } from 'cli-forge';
-
-cli('my-cli')
-  .command('hello', {
-    description: 'Say hello to the world',
-    builder: (args) =>
-      args.option('name', {
-        type: 'string',
-        description: 'The name to say hello to',
-      }),
-    handler: (args) => {
-      console.log(`Hello, ${args.name}!`);
-    },
-  })
-  .forge();
-```
-
-Then run the CLI with:
-
-```bash
-node my-cli.js hello --name "World"
-```
-
-Then, to generate documentation for the CLI, run:
-
-```bash
-npx cli-forge generate-docs my-cli.js
-```
-
-This should generate a folder called `docs` containing markdown documentation for the CLI. Alternatively, you can pass `--format json` to generate JSON documentation to further process.
+See the [examples gallery](https://craigory.dev/cli-forge/examples) and the [quick-start guide](https://craigory.dev/cli-forge/docs/guides/quick-start) for more.
 
 ## Subshells
 
@@ -134,53 +102,9 @@ By default, this will generate markdown documentation in a folder called `docs`.
 
 ## How It Compares
 
-### vs. Yargs
+CLI Forge is compared in detail with **yargs**, **commander**, **oclif**, **clipanion**, **cac**, **meow**, **citty**, **cleye**, **@effect/cli**, **gluegun**, and Node.js `util.parseArgs` in the [comparison guide](https://craigory.dev/cli-forge/docs/guides/comparison).
 
-CLI Forge shares a similar fluent API style with yargs, but makes different tradeoffs:
-
-**What CLI Forge adds:**
-
-- Superior TypeScript inference that tracks every option through the chain
-- Built-in middleware system for argument transformation
-- Interactive shell support (inspired by vorpal)
-- Integrated documentation generation (`cli-forge generate-docs`)
-- Test harness for unit testing CLI commands
-- Configuration file inheritance with `extends`
-
-**Intentional differences:**
-
-- **No usage string parsing** — To maintain type safety, options must be explicitly declared rather than parsed from usage strings
-- **No unknown option parsing** — Unknown options aren't captured by design; explicit option definitions ensure type safety
-- **No filesystem-based routing** — Commands are registered programmatically for better discoverability and refactoring support
-
-### vs. Commander
-
-Commander offers a lightweight API, while CLI Forge provides more structure:
-
-**CLI Forge advantages:**
-
-- Full TypeScript type inference throughout the argument chain
-- Richer option types (nested objects with typed properties)
-- Middleware composition
-- Built-in configuration file support with inheritance
-- Automatic documentation generation
-- Interactive shell mode
-
-### vs. Vorpal
-
-Vorpal pioneered interactive CLI shells but hasn't been maintained since 2018. CLI Forge brings that concept forward:
-
-**Modern improvements:**
-
-- Active maintenance with TypeScript-first design
-- Opt-in interactive shell (not required)
-- Contemporary Node.js and TypeScript support
-- Comprehensive testing utilities
-- Documentation generation tooling
-
-### Design Philosophy
-
-CLI Forge prioritizes **user type safety** over internal implementation purity. While the library uses type assertions internally where necessary due to TypeScript limitations, the public API provides full type inference and safety. The goal is a CLI framework that feels natural in TypeScript projects while catching as many errors as possible at compile time.
+The short version: CLI Forge prioritizes **full type inference** (every `.option()` call builds a TypeScript type), **composability** (middleware, composable builders, config file inheritance), and **integrated tooling** (doc generation, test harness, interactive shell) — features that most alternatives only partially cover or omit entirely.
 
 ## Contributing
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@types/hast": "^3.0.4",
     "@types/react": "^19.2.9",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",

--- a/docs-site/pages/playground/+Page.tsx
+++ b/docs-site/pages/playground/+Page.tsx
@@ -227,8 +227,11 @@ export default function PlaygroundPage() {
       const cliForgeImports = parseImports(code, 'cli-forge');
       const parserImports = parseImports(code, '@cli-forge/parser');
 
-      const stripped = code
-        // Strip package imports (ESM and CJS)
+      // Strip cli-forge/parser imports (we re-inject them as runtime vars),
+      // then use TypeScript's transpiler to handle all TS syntax (generics,
+      // type aliases, annotations, etc.) instead of fragile regex stripping.
+      const withoutPkgImports = code
+        // Strip cli-forge and parser imports (ESM and CJS)
         .replace(
           /import\s+(?:\{[^}]*\}|\w+)\s+from\s+['"](?:cli-forge|@cli-forge\/parser)['"];?\s*/g,
           ''
@@ -237,21 +240,28 @@ export default function PlaygroundPage() {
           /(?:const|let|var)\s+\{[^}]*\}\s*=\s*require\s*\(\s*['"](?:cli-forge|@cli-forge\/parser)['"]\s*\)\s*;?\s*/g,
           ''
         )
-        // Strip remaining imports (other packages) — not valid inside AsyncFunction
+        .replace(/\.forge\(\s*\)/g, '.forge(__argv__)');
+
+      const ts = await import('typescript');
+      const { outputText: transpiled } = ts.transpileModule(withoutPkgImports, {
+        compilerOptions: {
+          target: ts.ScriptTarget.ESNext,
+          module: ts.ModuleKind.ESNext,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+        },
+      });
+
+      // Post-transpile cleanup: strip remaining imports/exports that
+      // can't run inside AsyncFunction (value imports from other packages,
+      // export keywords on declarations, re-exports).
+      const stripped = transpiled
         .replace(/^\s*import\s+.*?from\s+['"][^'"]*['"];?\s*$/gm, '')
-        // Strip `export type X = ...;` and `export interface X { ... }` (TS-only)
-        .replace(/export\s+type\s+\w[^;]*;/g, '')
-        .replace(/export\s+interface\s+\w[\s\S]*?\n\}/gm, '')
-        // `export default <identifier>;` — remove the whole statement
         .replace(/^\s*export\s+default\s+(?!function\b|class\b|async\b)\S[^\n]*;?\s*$/gm, '')
-        // `export default function/class/async function` — strip `export default`
         .replace(/export\s+default\s+(?=(?:async\s+)?(?:function|class)\b)/g, '')
-        // `export { X, Y }` and `export * from '...'` — remove entirely
         .replace(/export\s*\{[^}]*\}\s*(?:from\s*['"][^'"]*['"])?\s*;?/g, '')
         .replace(/export\s+\*\s+(?:as\s+\w+\s+)?from\s+['"][^'"]*['"];\s*/g, '')
-        // `export const/let/var/function/class` — keep the declaration, strip `export`
-        .replace(/\bexport\s+(?=(?:async\s+)?(?:const|let|var|function|class)\b)/g, '')
-        .replace(/\.forge\(\s*\)/g, '.forge(__argv__)');
+        .replace(/\bexport\s+(?=(?:async\s+)?(?:const|let|var|function|class)\b)/g, '');
 
       const cliForge = await import('cli-forge');
       const parserPkg = await import('@cli-forge/parser');
@@ -464,11 +474,16 @@ export default function PlaygroundPage() {
               </span>
             )}
           </h1>
-          <p className="text-forge-ash mt-1 max-w-2xl text-sm">
-            {activeExample
-              ? activeExample.description
-              : 'Write CLI Forge code and see how it responds to different arguments and environment variables.'}
-          </p>
+          {activeExample ? (
+            <div
+              className="prose-content text-forge-ash mt-1 max-w-2xl text-sm"
+              dangerouslySetInnerHTML={{ __html: activeExample.descriptionHtml }}
+            />
+          ) : (
+            <p className="text-forge-ash mt-1 max-w-2xl text-sm">
+              Write CLI Forge code and see how it responds to different arguments and environment variables.
+            </p>
+          )}
         </div>
         {activeExample && (
           <Link

--- a/docs-site/pages/playground/+data.ts
+++ b/docs-site/pages/playground/+data.ts
@@ -39,7 +39,7 @@ function readDtsFiles(
 export interface PlaygroundExample {
   id: string;
   title: string;
-  description: string;
+  descriptionHtml: string;
   files: { path: string; content: string }[];
   commands: { name: string; args: string; env?: Record<string, string> }[];
 }
@@ -89,7 +89,7 @@ function toPlaygroundExample(ex: SiteExample): PlaygroundExample {
   return {
     id: ex.id,
     title: ex.title,
-    description: ex.description,
+    descriptionHtml: ex.renderedDescriptionHtml,
     files: ex.files
       .filter(
         (f) =>

--- a/packages/cli-forge/src/lib/composable-builder.ts
+++ b/packages/cli-forge/src/lib/composable-builder.ts
@@ -1,4 +1,4 @@
-import type { ParsedArgs } from '@cli-forge/parser';
+import type { Expand, ParsedArgs } from '@cli-forge/parser';
 import { CLI } from './public-api';
 
 /**
@@ -23,7 +23,7 @@ export type ComposableBuilder<
   TAddedChildren = {}
 > = <TInit extends ParsedArgs, THandlerReturn, TChildren, TParent>(
   init: CLI<TInit, THandlerReturn, TChildren, TParent>
-) => CLI<TInit & TArgs2, THandlerReturn, TChildren & TAddedChildren, TParent>;
+) => CLI<Expand<TInit & TArgs2>, THandlerReturn, TChildren & TAddedChildren, TParent>;
 
 /**
  * Creates a composable builder function that can be used with `chain`.
@@ -69,7 +69,7 @@ export function makeComposableBuilder<
       current = current[op.method](...op.args);
     }
     return current as unknown as CLI<
-      TInit & TArgs2,
+      Expand<TInit & TArgs2>,
       THandlerReturn,
       TChildren & TChildren2,
       TParent

--- a/packages/cli-forge/src/lib/utils.ts
+++ b/packages/cli-forge/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { getFileSystemProvider } from '@cli-forge/parser';
+import { type Expand, getFileSystemProvider } from '@cli-forge/parser';
 import { CLI } from './public-api';
 
 export function getCallingFile() {
@@ -141,5 +141,5 @@ export function stringToArgs(str: string) {
  * @typeParam T - A function that takes a CLI instance and returns a new CLI instance with additional options, commands etc.
  */
 export type ArgumentsOf<T> = T extends (...args: any[]) => CLI<infer TArgs>
-  ? TArgs
+  ? Expand<TArgs>
   : never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.1(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/react':
         specifier: ^19.2.9
         version: 19.2.14

--- a/type-tests/src/lib/composable-builders.spec.ts
+++ b/type-tests/src/lib/composable-builders.spec.ts
@@ -90,6 +90,48 @@ describe('Composable Builder Type Inference', () => {
       expect(typeHasProperty(result!.type, 'count')).toBe(true);
     });
 
+    it('should produce flat type from ArgumentsOf with composed builders', () => {
+      const code = `
+        import { cli, chain, makeComposableBuilder, ArgumentsOf, CLI } from 'cli-forge';
+
+        const withName = makeComposableBuilder((args) =>
+          args.option('name', { type: 'string', required: true })
+        );
+
+        const withAge = makeComposableBuilder((args) =>
+          args.option('age', { type: 'number', required: true })
+        );
+
+        const builder = <T extends CLI>(args: T) => chain(args, withName, withAge);
+
+        type Args = ArgumentsOf<typeof builder>;
+
+        const testArgs: Args = null! as Args;
+        const _check: string = testArgs.name;
+        const _check2: number = testArgs.age;
+      `;
+
+      const { typeChecker, sourceFile } = createTestProgram(code);
+
+      // Find the Args type alias
+      let argsType: ts.Type | null = null;
+      ts.forEachChild(sourceFile, (node) => {
+        if (
+          ts.isTypeAliasDeclaration(node) &&
+          node.name.text === 'Args'
+        ) {
+          argsType = typeChecker.getTypeAtLocation(node);
+        }
+      });
+
+      expect(argsType).not.toBeNull();
+      const typeString = typeChecker.typeToString(argsType!);
+
+      // Should be a flat object type, not an intersection chain
+      expect(typeString).not.toContain('MakeUndefinedPropertiesOptional');
+      expect(typeString).not.toContain('Expand');
+    });
+
     it('should handle optional vs required in handler', () => {
       const code = `
         import { cli } from 'cli-forge';


### PR DESCRIPTION
## Summary

- Wraps `ComposableBuilder` and `makeComposableBuilder` return types with `Expand<>` so `chain()`-composed builders produce flat object types instead of intersection chains
- Wraps `ArgumentsOf` extracted `TArgs` in `Expand<>` as a safety net for cleaner tooltips
- Adds type test validating `ArgumentsOf` with composed builders produces flat types (no `MakeUndefinedPropertiesOptional` or `Expand` visible in type string)

**Before:** `ArgumentsOf<typeof builder>` showed `ParsedArgs & MakeUndefinedPropertiesOptional<{ name: string }> & MakeUndefinedPropertiesOptional<{ age: number }>`

**After:** `ArgumentsOf<typeof builder>` shows `{ name: string; age: number; unmatched: string[] }`

## Test plan
- [x] All 69 type tests pass (including 1 new)
- [x] cli-forge unit tests pass
- [x] Build succeeds