### PR TITLE
feat(docs-site): add clickable anchor links to headings

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -188,9 +188,11 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+            const shortSha = sha.slice(0, 7);
             const previewUrl = `https://craigory.dev/cli-forge/pr/${prNumber}/`;
             const marker = '<!-- docs-preview-comment -->';
-            const body = `${marker}\n**Docs Preview:** ${previewUrl}`;
+            const body = `${marker}\n**Docs Preview:** ${previewUrl}\n\nDeployed commit: ${shortSha} (${sha})`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,9 +118,11 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+            const shortSha = sha.slice(0, 7);
             const previewUrl = `https://craigory.dev/cli-forge/pr/${prNumber}/`;
             const marker = '<!-- docs-preview-comment -->';
-            const body = `${marker}\n**Docs Preview:** ${previewUrl}`;
+            const body = `${marker}\n**Docs Preview:** ${previewUrl}\n\nDeployed commit: ${shortSha} (${sha})`;
 
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.563.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "rehype-autolink-headings": "^7.1.0",
     "rehype-github-alerts": "^4.2.0",
     "rehype-parse": "^9.0.1",
     "rehype-raw": "^7.0.0",

--- a/docs-site/pages/+Layout.tsx
+++ b/docs-site/pages/+Layout.tsx
@@ -33,6 +33,22 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     setMobileMenuOpen(false);
   }, [pathname]);
 
+  // Global click handler for heading anchor links — copies the heading URL to clipboard
+  useEffect(() => {
+    function handleAnchorClick(e: MouseEvent) {
+      const anchor = (e.target as Element).closest?.('a.heading-anchor');
+      if (!anchor) return;
+      e.preventDefault();
+      const url = new URL(anchor.getAttribute('href')!, window.location.href);
+      url.pathname = window.location.pathname;
+      navigator.clipboard.writeText(url.toString());
+      anchor.classList.add('copied');
+      setTimeout(() => anchor.classList.remove('copied'), 1500);
+    }
+    document.addEventListener('click', handleAnchorClick);
+    return () => document.removeEventListener('click', handleAnchorClick);
+  }, []);
+
   return (
     <div className="min-h-screen bg-forge-bg text-forge-smoke relative">
       <ForgeBackground />

--- a/docs-site/pages/tailwind.css
+++ b/docs-site/pages/tailwind.css
@@ -103,22 +103,18 @@ a.line-number:hover {
   margin-bottom: 0.75em;
   font-weight: 700;
   letter-spacing: 0.02em;
-  position: relative;
 }
 
 /* Heading anchor links */
 .prose-content .heading-anchor {
-  position: absolute;
-  left: -1.5em;
-  top: 50%;
-  transform: translateY(-50%);
   color: transparent;
   text-decoration: none;
   transition: color 0.15s ease;
-  line-height: 1;
+  margin-left: 0.5em;
+  vertical-align: middle;
 }
 .prose-content .heading-anchor svg {
-  display: block;
+  display: inline-block;
 }
 .prose-content h1:hover .heading-anchor,
 .prose-content h2:hover .heading-anchor,

--- a/docs-site/pages/tailwind.css
+++ b/docs-site/pages/tailwind.css
@@ -103,6 +103,7 @@ a.line-number:hover {
   margin-bottom: 0.75em;
   font-weight: 700;
   letter-spacing: 0.02em;
+  scroll-margin-top: 4.5rem;
 }
 
 /* Heading anchor links */

--- a/docs-site/pages/tailwind.css
+++ b/docs-site/pages/tailwind.css
@@ -103,6 +103,35 @@ a.line-number:hover {
   margin-bottom: 0.75em;
   font-weight: 700;
   letter-spacing: 0.02em;
+  position: relative;
+}
+
+/* Heading anchor links */
+.prose-content .heading-anchor {
+  position: absolute;
+  left: -1.5em;
+  top: 50%;
+  transform: translateY(-50%);
+  color: transparent;
+  text-decoration: none;
+  transition: color 0.15s ease;
+  line-height: 1;
+}
+.prose-content .heading-anchor svg {
+  display: block;
+}
+.prose-content h1:hover .heading-anchor,
+.prose-content h2:hover .heading-anchor,
+.prose-content h3:hover .heading-anchor,
+.prose-content h4:hover .heading-anchor,
+.prose-content .heading-anchor:focus-visible {
+  color: #6a5040;
+}
+.prose-content .heading-anchor:hover {
+  color: #ff8c38 !important;
+}
+.prose-content .heading-anchor.copied {
+  color: #7cc9a0 !important;
 }
 .prose-content h1 { font-size: 1.5rem; }
 .prose-content h2 {

--- a/docs-site/server/utils/markdown.ts
+++ b/docs-site/server/utils/markdown.ts
@@ -1,6 +1,7 @@
 import rehypeParse from 'rehype-parse';
 import rehypeShiki from '@shikijs/rehype';
 import { rehypeGithubAlerts } from 'rehype-github-alerts';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeRaw from 'rehype-raw';
 import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
@@ -102,6 +103,47 @@ export async function renderMarkdown(md: string): Promise<string> {
     .use(rehypeRaw)
     .use(rehypeBaseUrl)
     .use(rehypeSlug)
+    .use(rehypeAutolinkHeadings, {
+      behavior: 'prepend',
+      properties: {
+        className: ['heading-anchor'],
+        ariaHidden: 'true',
+        tabIndex: -1,
+      },
+      content: {
+        type: 'element',
+        tagName: 'svg',
+        properties: {
+          xmlns: 'http://www.w3.org/2000/svg',
+          width: 16,
+          height: 16,
+          viewBox: '0 0 24 24',
+          fill: 'none',
+          stroke: 'currentColor',
+          strokeWidth: 2,
+          strokeLinecap: 'round',
+          strokeLinejoin: 'round',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'path',
+            properties: {
+              d: 'M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71',
+            },
+            children: [],
+          },
+          {
+            type: 'element',
+            tagName: 'path',
+            properties: {
+              d: 'M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71',
+            },
+            children: [],
+          },
+        ],
+      },
+    })
     .use(rehypeGithubAlerts, {});
 
   // Syntax highlighting via @shikijs/rehype

--- a/docs-site/server/utils/markdown.ts
+++ b/docs-site/server/utils/markdown.ts
@@ -104,7 +104,7 @@ export async function renderMarkdown(md: string): Promise<string> {
     .use(rehypeBaseUrl)
     .use(rehypeSlug)
     .use(rehypeAutolinkHeadings, {
-      behavior: 'prepend',
+      behavior: 'append',
       properties: {
         className: ['heading-anchor'],
         ariaHidden: 'true',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.4(react@19.2.4)
+      rehype-autolink-headings:
+        specifier: ^7.1.0
+        version: 7.1.0
       rehype-github-alerts:
         specifier: ^4.2.0
         version: 4.2.0
@@ -5759,6 +5762,9 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
 
   rehype-github-alerts@4.2.0:
     resolution: {integrity: sha512-6di6kEu9WUHKLKrkKG2xX6AOuaCMGghg0Wq7MEuM/jBYUPVIq6PJpMe00dxMfU+/YSBtDXhffpDimgDi+BObIQ==}
@@ -12898,6 +12904,15 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
 
   rehype-github-alerts@4.2.0:
     dependencies:


### PR DESCRIPTION
Adds rehype-autolink-headings to the markdown pipeline so every heading
gets a link icon that appears on hover. Clicking it copies the heading
URL to the clipboard with brief visual feedback (green flash).

https://claude.ai/code/session_01SrrHqq7E7TUwLM1y2oUeAE