### PR TITLE
feat(cli-forge): display object option property details in --help output

### DIFF
--- a/packages/cli-forge/src/lib/format-help.ts
+++ b/packages/cli-forge/src/lib/format-help.ts
@@ -157,6 +157,38 @@ function removeTrailingAndLeadingQuotes(str: string) {
   return str.replace(/^['"]/, '').replace(/['"]$/, '');
 }
 
+/**
+ * Extract the merged properties from a oneOf config's object valueTypes.
+ * When a oneOf has object branches, their properties can be set via dot notation,
+ * so we merge them for display in help output.
+ */
+function getOneOfObjectProperties(
+  config: UnknownOptionConfig
+): Record<string, UnknownOptionConfig> | undefined {
+  if (!isOneOfOptionConfig(config)) return undefined;
+  const merged: Record<string, UnknownOptionConfig> = {};
+  let found = false;
+  for (const vt of config.valueTypes) {
+    if (
+      vt.type === 'object' &&
+      'properties' in vt &&
+      vt.properties &&
+      typeof vt.properties === 'object'
+    ) {
+      found = true;
+      for (const [k, v] of Object.entries(
+        vt.properties as Record<string, UnknownOptionConfig>
+      )) {
+        // First object branch wins for any given key
+        if (!(k in merged)) {
+          merged[k] = v;
+        }
+      }
+    }
+  }
+  return found ? merged : undefined;
+}
+
 function collectObjectProperties(
   parentKey: string,
   properties: Record<string, UnknownOptionConfig>
@@ -173,6 +205,11 @@ function collectObjectProperties(
           config.properties as Record<string, UnknownOptionConfig>
         )
       );
+    } else {
+      const oneOfProps = getOneOfObjectProperties(config);
+      if (oneOfProps) {
+        result.push(...collectObjectProperties(fullKey, oneOfProps));
+      }
     }
   }
   return result;
@@ -253,6 +290,11 @@ function getOptionBlock(
           option.properties as Record<string, UnknownOptionConfig>
         )
       );
+    } else {
+      const oneOfProps = getOneOfObjectProperties(option);
+      if (oneOfProps) {
+        lines.push(...getPropertyLines(option.key, oneOfProps));
+      }
     }
   }
   return lines;

--- a/packages/cli-forge/src/lib/format-help.ts
+++ b/packages/cli-forge/src/lib/format-help.ts
@@ -3,6 +3,7 @@ import {
   UnknownOptionConfig,
   readDefaultValue,
   isOneOfOptionConfig,
+  isObjectOptionConfig,
 } from '@cli-forge/parser';
 import { InternalCLI } from './internal-cli';
 
@@ -156,6 +157,60 @@ function removeTrailingAndLeadingQuotes(str: string) {
   return str.replace(/^['"]/, '').replace(/['"]$/, '');
 }
 
+function collectObjectProperties(
+  parentKey: string,
+  properties: Record<string, UnknownOptionConfig>
+): Array<{ key: string; config: UnknownOptionConfig }> {
+  const result: Array<{ key: string; config: UnknownOptionConfig }> = [];
+  for (const [name, config] of Object.entries(properties)) {
+    if (config.hidden) continue;
+    const fullKey = `${parentKey}.${name}`;
+    result.push({ key: fullKey, config });
+    if (isObjectOptionConfig(config) && config.properties) {
+      result.push(
+        ...collectObjectProperties(
+          fullKey,
+          config.properties as Record<string, UnknownOptionConfig>
+        )
+      );
+    }
+  }
+  return result;
+}
+
+function getPropertyLines(
+  parentKey: string,
+  properties: Record<string, UnknownOptionConfig>
+): string[] {
+  const flatProps = collectObjectProperties(parentKey, properties);
+  if (flatProps.length === 0) return [];
+
+  const allParts: Array<[key: string, ...parts: string[]]> = [];
+  for (const { key, config } of flatProps) {
+    allParts.push([key, ...getOptionParts(config)]);
+  }
+
+  const paddingValues: number[] = [];
+  for (let i = 0; i < allParts.length; i++) {
+    for (let j = 0; j < allParts[i].length; j++) {
+      if (!paddingValues[j]) {
+        paddingValues[j] = 0;
+      }
+      paddingValues[j] = Math.max(paddingValues[j], allParts[i][j].length);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [key, ...parts] of allParts) {
+    lines.push(
+      `    --${key.padEnd(paddingValues[0])}${parts.length ? ' - ' : ''}${parts
+        .map((part, i) => part.padEnd(paddingValues[i + 1]))
+        .join(' ')}`
+    );
+  }
+  return lines;
+}
+
 function getOptionBlock(
   label: string,
   options: InternalOptionConfig[],
@@ -183,12 +238,22 @@ function getOptionBlock(
       paddingValues[j] = Math.max(paddingValues[j], allParts[i][j].length);
     }
   }
-  for (const [key, ...parts] of allParts) {
+  for (let i = 0; i < allParts.length; i++) {
+    const [key, ...parts] = allParts[i];
     lines.push(
       `  --${key.padEnd(paddingValues[0])}${parts.length ? ' - ' : ''}${parts
-        .map((part, i) => part.padEnd(paddingValues[i + 1]))
+        .map((part, j) => part.padEnd(paddingValues[j + 1]))
         .join(' ')}`
     );
+    const option = options[i];
+    if (isObjectOptionConfig(option) && option.properties) {
+      lines.push(
+        ...getPropertyLines(
+          option.key,
+          option.properties as Record<string, UnknownOptionConfig>
+        )
+      );
+    }
   }
   return lines;
 }

--- a/packages/cli-forge/src/lib/format-help.ts
+++ b/packages/cli-forge/src/lib/format-help.ts
@@ -215,37 +215,20 @@ function collectObjectProperties(
   return result;
 }
 
-function getPropertyLines(
-  parentKey: string,
-  properties: Record<string, UnknownOptionConfig>
-): string[] {
-  const flatProps = collectObjectProperties(parentKey, properties);
-  if (flatProps.length === 0) return [];
-
-  const allParts: Array<[key: string, ...parts: string[]]> = [];
-  for (const { key, config } of flatProps) {
-    allParts.push([key, ...getOptionParts(config)]);
+function getPropertyEntries(
+  option: UnknownOptionConfig
+): Array<{ key: string; config: UnknownOptionConfig }> {
+  let properties: Record<string, UnknownOptionConfig> | undefined;
+  if (isObjectOptionConfig(option) && option.properties) {
+    properties = option.properties as Record<string, UnknownOptionConfig>;
+  } else {
+    properties = getOneOfObjectProperties(option);
   }
-
-  const paddingValues: number[] = [];
-  for (let i = 0; i < allParts.length; i++) {
-    for (let j = 0; j < allParts[i].length; j++) {
-      if (!paddingValues[j]) {
-        paddingValues[j] = 0;
-      }
-      paddingValues[j] = Math.max(paddingValues[j], allParts[i][j].length);
-    }
-  }
-
-  const lines: string[] = [];
-  for (const [key, ...parts] of allParts) {
-    lines.push(
-      `    --${key.padEnd(paddingValues[0])}${parts.length ? ' - ' : ''}${parts
-        .map((part, i) => part.padEnd(paddingValues[i + 1]))
-        .join(' ')}`
-    );
-  }
-  return lines;
+  if (!properties) return [];
+  return collectObjectProperties(
+    (option as InternalOptionConfig).key,
+    properties
+  );
 }
 
 function getOptionBlock(
@@ -260,42 +243,45 @@ function getOptionBlock(
     lines.push(label + ':');
   }
 
-  const allParts: Array<[key: string, ...parts: string[]]> = [];
+  // Collect all entries (options + their property sub-entries) into a flat list
+  const entries: Array<{
+    key: string;
+    parts: string[];
+    indent: number;
+  }> = [];
+
   for (const option of options) {
-    // Use the display key (localized) instead of the storage key
     const displayKey = parser.getDisplayKey(option.key);
-    allParts.push([displayKey, ...getOptionParts(option)]);
-  }
-  const paddingValues: number[] = [];
-  for (let i = 0; i < allParts.length; i++) {
-    for (let j = 0; j < allParts[i].length; j++) {
-      if (!paddingValues[j]) {
-        paddingValues[j] = 0;
-      }
-      paddingValues[j] = Math.max(paddingValues[j], allParts[i][j].length);
+    entries.push({ key: displayKey, parts: getOptionParts(option), indent: 0 });
+    for (const { key, config } of getPropertyEntries(option)) {
+      entries.push({ key, parts: getOptionParts(config), indent: 2 });
     }
   }
-  for (let i = 0; i < allParts.length; i++) {
-    const [key, ...parts] = allParts[i];
+
+  // Compute key column width accounting for indent so all `-` separators align
+  let keyColumnWidth = 0;
+  for (const entry of entries) {
+    keyColumnWidth = Math.max(keyColumnWidth, entry.indent + entry.key.length);
+  }
+
+  // Compute padding for each part column across all entries
+  const partPadding: number[] = [];
+  for (const entry of entries) {
+    for (let j = 0; j < entry.parts.length; j++) {
+      if (!partPadding[j]) {
+        partPadding[j] = 0;
+      }
+      partPadding[j] = Math.max(partPadding[j], entry.parts[j].length);
+    }
+  }
+
+  for (const { key, parts, indent } of entries) {
+    const paddedKey = key.padEnd(keyColumnWidth - indent);
     lines.push(
-      `  --${key.padEnd(paddingValues[0])}${parts.length ? ' - ' : ''}${parts
-        .map((part, j) => part.padEnd(paddingValues[j + 1]))
-        .join(' ')}`
+      `${' '.repeat(2 + indent)}--${paddedKey}${
+        parts.length ? ' - ' : ''
+      }${parts.map((part, i) => part.padEnd(partPadding[i])).join(' ')}`
     );
-    const option = options[i];
-    if (isObjectOptionConfig(option) && option.properties) {
-      lines.push(
-        ...getPropertyLines(
-          option.key,
-          option.properties as Record<string, UnknownOptionConfig>
-        )
-      );
-    } else {
-      const oneOfProps = getOneOfObjectProperties(option);
-      if (oneOfProps) {
-        lines.push(...getPropertyLines(option.key, oneOfProps));
-      }
-    }
   }
   return lines;
 }

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -434,11 +434,11 @@ describe('cliForge', () => {
       "Usage: test
 
       Options:
-        --help    - Show help for the current command  
-        --version - Show the version number for the CLI
-        --config  - App configuration                  
-          --config.host - Server hostname [default: localhost]
-          --config.port - Server port     [required]          "
+        --help          - Show help for the current command  
+        --version       - Show the version number for the CLI
+        --config        - App configuration                  
+          --config.host - Server hostname                     [default: localhost]
+          --config.port - Server port                         [required]          "
     `);
   });
 
@@ -475,13 +475,13 @@ describe('cliForge', () => {
       "Usage: test
 
       Options:
-        --help    - Show help for the current command  
-        --version - Show the version number for the CLI
-        --config  - App configuration                  
-          --config.server      - Server settings  
-          --config.server.host - Hostname          [default: localhost]
-          --config.server.port - Port number      
-          --config.debug       - Enable debug mode"
+        --help                 - Show help for the current command  
+        --version              - Show the version number for the CLI
+        --config               - App configuration                  
+          --config.server      - Server settings                    
+          --config.server.host - Hostname                            [default: localhost]
+          --config.server.port - Port number                        
+          --config.debug       - Enable debug mode                  "
     `);
   });
 
@@ -513,12 +513,12 @@ describe('cliForge', () => {
       "Usage: test
 
       Options:
-        --help    - Show help for the current command  
-        --version - Show the version number for the CLI
-        --filter  - Filter criteria                    
-          --filter.prs     - PR count filter [object|string]
-          --filter.prs.min - Minimum PRs    
-          --filter.prs.max - Maximum PRs    "
+        --help             - Show help for the current command  
+        --version          - Show the version number for the CLI
+        --filter           - Filter criteria                    
+          --filter.prs     - PR count filter                     [object|string]
+          --filter.prs.min - Minimum PRs                        
+          --filter.prs.max - Maximum PRs                        "
     `);
   });
 
@@ -544,11 +544,11 @@ describe('cliForge', () => {
       "Usage: test
 
       Options:
-        --help    - Show help for the current command  
-        --version - Show the version number for the CLI
-        --value   - A flexible value                    [object|string]
-          --value.host - Hostname
-          --value.port - Port     [default: 8080]"
+        --help         - Show help for the current command  
+        --version      - Show the version number for the CLI
+        --value        - A flexible value                    [object|string]
+          --value.host - Hostname                           
+          --value.port - Port                                [default: 8080]"
     `);
   });
 

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -485,6 +485,73 @@ describe('cliForge', () => {
     `);
   });
 
+  it('should display oneOf object property sub-properties in help', async () => {
+    const { getOutput } = mockConsoleLog();
+    await cli('test')
+      .option('filter', {
+        type: 'object',
+        description: 'Filter criteria',
+        properties: {
+          prs: {
+            type: 'oneOf',
+            description: 'PR count filter',
+            valueTypes: [
+              {
+                type: 'object',
+                properties: {
+                  min: { type: 'number', description: 'Minimum PRs' },
+                  max: { type: 'number', description: 'Maximum PRs' },
+                },
+              },
+              { type: 'string' },
+            ],
+          } as any,
+        },
+      })
+      .forge(['--help']);
+    expect(getOutput()).toMatchInlineSnapshot(`
+      "Usage: test
+
+      Options:
+        --help    - Show help for the current command  
+        --version - Show the version number for the CLI
+        --filter  - Filter criteria                    
+          --filter.prs     - PR count filter [object|string]
+          --filter.prs.min - Minimum PRs    
+          --filter.prs.max - Maximum PRs    "
+    `);
+  });
+
+  it('should display top-level oneOf with object valueType properties in help', async () => {
+    const { getOutput } = mockConsoleLog();
+    await cli('test')
+      .option('value', {
+        type: 'oneOf',
+        description: 'A flexible value',
+        valueTypes: [
+          {
+            type: 'object',
+            properties: {
+              host: { type: 'string', description: 'Hostname' },
+              port: { type: 'number', description: 'Port', default: 8080 },
+            },
+          },
+          { type: 'string' },
+        ],
+      } as any)
+      .forge(['--help']);
+    expect(getOutput()).toMatchInlineSnapshot(`
+      "Usage: test
+
+      Options:
+        --help    - Show help for the current command  
+        --version - Show the version number for the CLI
+        --value   - A flexible value                    [object|string]
+          --value.host - Hostname
+          --value.port - Port     [default: 8080]"
+    `);
+  });
+
   it('should run middlewares before command handlers', async () => {
     const executionOrder: string[] = [];
     await cli('test')

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -410,6 +410,81 @@ describe('cliForge', () => {
     `);
   });
 
+  it('should display object option property details in help', async () => {
+    const { getOutput } = mockConsoleLog();
+    await cli('test')
+      .option('config', {
+        type: 'object',
+        description: 'App configuration',
+        properties: {
+          host: {
+            type: 'string',
+            description: 'Server hostname',
+            default: 'localhost',
+          },
+          port: {
+            type: 'number',
+            description: 'Server port',
+            required: true,
+          },
+        },
+      })
+      .forge(['--help']);
+    expect(getOutput()).toMatchInlineSnapshot(`
+      "Usage: test
+
+      Options:
+        --help    - Show help for the current command  
+        --version - Show the version number for the CLI
+        --config  - App configuration                  
+          --config.host - Server hostname [default: localhost]
+          --config.port - Server port     [required]          "
+    `);
+  });
+
+  it('should display nested object property details in help', async () => {
+    const { getOutput } = mockConsoleLog();
+    await cli('test')
+      .option('config', {
+        type: 'object',
+        description: 'App configuration',
+        properties: {
+          server: {
+            type: 'object',
+            description: 'Server settings',
+            properties: {
+              host: {
+                type: 'string',
+                description: 'Hostname',
+                default: 'localhost',
+              },
+              port: {
+                type: 'number',
+                description: 'Port number',
+              },
+            },
+          },
+          debug: {
+            type: 'boolean',
+            description: 'Enable debug mode',
+          },
+        },
+      })
+      .forge(['--help']);
+    expect(getOutput()).toMatchInlineSnapshot(`
+      "Usage: test
+
+      Options:
+        --help    - Show help for the current command  
+        --version - Show the version number for the CLI
+        --config  - App configuration                  
+          --config.server      - Server settings  
+          --config.server.host - Hostname          [default: localhost]
+          --config.server.port - Port number      
+          --config.debug       - Enable debug mode"
+    `);
+  });
+
   it('should run middlewares before command handlers', async () => {
     const executionOrder: string[] = [];
     await cli('test')


### PR DESCRIPTION
When an option has type 'object' with properties, the help output now
shows each property with dot notation, indented under the parent option.
Nested objects are recursively expanded and hidden properties are skipped.

https://claude.ai/code/session_01DiheMMah8eQcVuPESnDkm7