### PR TITLE
docs(cli-forge): validate dual-format publish with bundling examples

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -54,7 +54,7 @@
     "implicitDependencies": [
       "cli-forge",
       "parser",
-      "cli-forge-examples"
+      "examples"
     ],
     "targets": {
       "build": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -53,7 +53,8 @@
     "name": "docs-site",
     "implicitDependencies": [
       "cli-forge",
-      "parser"
+      "parser",
+      "cli-forge-examples"
     ],
     "targets": {
       "build": {

--- a/docs-site/pages/examples/@id/+Page.tsx
+++ b/docs-site/pages/examples/@id/+Page.tsx
@@ -170,12 +170,14 @@ export default function ExampleDetailPage() {
               {tag}
             </span>
           ))}
-          <Link
-            href={`/playground?example=${example.id}`}
-            className="inline-flex items-center gap-1.5 px-3 py-0.5 bg-forge-flame hover:bg-forge-flame-bright text-forge-bg text-xs font-semibold uppercase rounded transition-colors no-underline"
-          >
-            Try in Playground
-          </Link>
+          {example.metadata.playground !== false && (
+            <Link
+              href={`/playground?example=${example.id}`}
+              className="inline-flex items-center gap-1.5 px-3 py-0.5 bg-forge-flame hover:bg-forge-flame-bright text-forge-bg text-xs font-semibold uppercase rounded transition-colors no-underline"
+            >
+              Try in Playground
+            </Link>
+          )}
         </div>
       </div>
 

--- a/docs-site/pages/playground/+data.ts
+++ b/docs-site/pages/playground/+data.ts
@@ -113,6 +113,7 @@ export function data(pageContext: PageContextServer): PlaygroundData {
   >;
 
   for (const [id, ex] of Object.entries(siteExamples)) {
+    if (ex.metadata.playground === false) continue;
     examples[id] = toPlaygroundExample(ex);
   }
 

--- a/docs-site/server/utils/examples.ts
+++ b/docs-site/server/utils/examples.ts
@@ -194,7 +194,7 @@ export async function loadExamples(): Promise<LoadExamplesResult> {
   const examples: SiteExample[] = [];
 
   for (const ex of result.examples) {
-    if ((ex.metadata as Record<string, unknown>)?.hidden) continue;
+    if (ex.metadata?.hidden) continue;
 
     const files = await Promise.all(
       ex.files.map((f) => transformFile(f, highlighter))
@@ -258,7 +258,9 @@ export async function loadExamples(): Promise<LoadExamplesResult> {
       ),
       renderedProseHtml,
       proseBlocks,
-      headings: extractHeadings(renderedDescriptionHtml + (renderedProseHtml ?? '')),
+      headings: extractHeadings(
+        renderedDescriptionHtml + (renderedProseHtml ?? '')
+      ),
       metadata,
     });
   }

--- a/examples/bundling/cjs/bun.ts
+++ b/examples/bundling/cjs/bun.ts
@@ -1,0 +1,7 @@
+// Bun.build() is a Bun-runtime API. This script shells out to
+// the bun CLI to stay compatible with the Node-based test runner.
+import { execSync } from 'child_process';
+
+execSync('bun build cli.ts --outfile dist/cjs/bun.cjs --target node --format cjs', {
+  stdio: 'inherit',
+});

--- a/examples/bundling/cjs/bun.ts
+++ b/examples/bundling/cjs/bun.ts
@@ -1,7 +1,12 @@
-// Bun.build() is a Bun-runtime API. This script shells out to
-// the bun CLI to stay compatible with the Node-based test runner.
-import { execSync } from 'child_process';
-
-execSync('bun build cli.ts --outfile dist/cjs/bun.cjs --target node --format cjs', {
-  stdio: 'inherit',
+const result = await Bun.build({
+  entrypoints: ['cli.ts'],
+  outdir: 'dist/cjs',
+  target: 'node',
+  format: 'cjs',
+  naming: 'bun.cjs',
 });
+
+if (!result.success) {
+  console.error(result.logs);
+  process.exit(1);
+}

--- a/examples/bundling/cjs/esbuild.ts
+++ b/examples/bundling/cjs/esbuild.ts
@@ -1,0 +1,11 @@
+import esbuild from 'esbuild';
+
+esbuild.buildSync({
+  entryPoints: ['cli-esbuild-cjs.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  outfile: 'dist/cjs/esbuild.cjs',
+  tsconfig: '../tsconfig.json',
+  logLevel: 'warning',
+});

--- a/examples/bundling/cjs/rolldown.ts
+++ b/examples/bundling/cjs/rolldown.ts
@@ -1,0 +1,15 @@
+import { rolldown } from 'rolldown';
+
+(async () => {
+  const bundle = await rolldown({
+    input: 'cli.ts',
+    platform: 'node',
+    resolve: { tsconfigFilename: '../tsconfig.json' },
+  });
+  await bundle.write({
+    format: 'cjs',
+    file: 'dist/cjs/rolldown.cjs',
+    codeSplitting: false,
+  });
+  await bundle.close();
+})();

--- a/examples/bundling/cjs/rollup.config.mjs
+++ b/examples/bundling/cjs/rollup.config.mjs
@@ -1,0 +1,11 @@
+import nodeResolve from '@rollup/plugin-node-resolve';
+
+export default {
+  input: 'cli.ts',
+  plugins: [nodeResolve()],
+  output: {
+    format: 'cjs',
+    file: 'dist/cjs/rollup.cjs',
+    inlineDynamicImports: true,
+  },
+};

--- a/examples/bundling/cjs/run-bun.sh
+++ b/examples/bundling/cjs/run-bun.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx cjs/bun.ts

--- a/examples/bundling/cjs/run-bun.sh
+++ b/examples/bundling/cjs/run-bun.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
-npx tsx cjs/bun.ts
+bun run cjs/bun.ts

--- a/examples/bundling/cjs/run-esbuild.sh
+++ b/examples/bundling/cjs/run-esbuild.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsx cjs/esbuild.ts

--- a/examples/bundling/cjs/run-esbuild.sh
+++ b/examples/bundling/cjs/run-esbuild.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx cjs/esbuild.ts

--- a/examples/bundling/cjs/run-rolldown.sh
+++ b/examples/bundling/cjs/run-rolldown.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx cjs/rolldown.ts

--- a/examples/bundling/cjs/run-rolldown.sh
+++ b/examples/bundling/cjs/run-rolldown.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsx cjs/rolldown.ts

--- a/examples/bundling/cjs/run-rollup.sh
+++ b/examples/bundling/cjs/run-rollup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx rollup -c cjs/rollup.config.mjs --silent

--- a/examples/bundling/cjs/run-rollup.sh
+++ b/examples/bundling/cjs/run-rollup.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx rollup -c cjs/rollup.config.mjs --silent

--- a/examples/bundling/cjs/run-tsdown.sh
+++ b/examples/bundling/cjs/run-tsdown.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsdown cli.ts --format cjs --outDir dist/cjs --platform node --no-dts

--- a/examples/bundling/cjs/run-tsdown.sh
+++ b/examples/bundling/cjs/run-tsdown.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsdown cli.ts --format cjs --outDir dist/cjs --platform node --no-dts

--- a/examples/bundling/cli-esbuild-cjs.ts
+++ b/examples/bundling/cli-esbuild-cjs.ts
@@ -1,0 +1,35 @@
+// #region import
+// For esbuild CJS bundles, use `import = require(...)` instead of
+// `import ... from`. This tells esbuild to resolve the "require"
+// export condition, picking up the CJS entry from dual-format packages.
+//
+// `import ... from` would activate the "import" condition regardless
+// of the output format, pulling in ESM files that may use import.meta.
+import cliForge = require('cli-forge');
+// #endregion import
+
+const cli = cliForge.default('bundled-cli')
+  .command('greet', {
+    builder: (args) =>
+      args.option('name', {
+        type: 'string',
+        default: 'World',
+        description: 'Who to greet',
+      }),
+    handler: (args) => {
+      console.log(`Hello, ${args.name}!`);
+    },
+  })
+  .command('add', {
+    builder: (args) =>
+      args
+        .option('a', { type: 'number', required: true })
+        .option('b', { type: 'number', required: true }),
+    handler: (args) => {
+      console.log(`${args.a} + ${args.b} = ${args.a + args.b}`);
+    },
+  });
+
+export default cli;
+
+cli.forge();

--- a/examples/bundling/cli.ts
+++ b/examples/bundling/cli.ts
@@ -1,0 +1,27 @@
+import cliForge from 'cli-forge';
+
+const cli = cliForge('bundled-cli')
+  .command('greet', {
+    builder: (args) =>
+      args.option('name', {
+        type: 'string',
+        default: 'World',
+        description: 'Who to greet',
+      }),
+    handler: (args) => {
+      console.log(`Hello, ${args.name}!`);
+    },
+  })
+  .command('add', {
+    builder: (args) =>
+      args
+        .option('a', { type: 'number', required: true })
+        .option('b', { type: 'number', required: true }),
+    handler: (args) => {
+      console.log(`${args.a} + ${args.b} = ${args.a + args.b}`);
+    },
+  });
+
+export default cli;
+
+cli.forge();

--- a/examples/bundling/content.md
+++ b/examples/bundling/content.md
@@ -4,6 +4,30 @@ Bundling is **not required** to distribute a cli-forge CLI. You can publish your
 
 That said, bundling can be useful when you want a single portable file, faster cold starts, or when embedding a CLI inside a larger tool.
 
+## Which tool should I pick?
+
+If you want the simplest setup, Bun is a strong option. It has a built-in bundler, and [`bun build --compile`](https://bun.sh/docs/bundler/executables) can produce a standalone executable that embeds the Bun runtime, so Bun does not become a runtime dependency for your users.
+
+If you want to stay Node-only, esbuild and Rolldown are both good default choices. Rollup gives you a similar model with a more established plugin ecosystem, while tsdown is a good fit when you want bundler-style transforms and tree-shaking without necessarily producing a fully self-contained single-file bundle.
+
+## Shipping a bundled CLI
+
+The examples below focus on module-format compatibility and bundling behavior. If you want to publish the built output as an executable CLI, there is one extra packaging step: make sure the final file has a Node shebang and is exposed through your package's `bin` field.
+
+```typescript
+#!/usr/bin/env node
+```
+
+```json
+{
+  "bin": {
+    "my-cli": "./dist/esm/my-cli.mjs"
+  }
+}
+```
+
+Most bundlers can prepend the shebang with a banner option, or you can add it in a small postbuild step and mark the file as executable with `chmod +x`.
+
 ## Shared CLI source
 
 All builds (except esbuild CJS) use this shared entry point:
@@ -62,7 +86,7 @@ Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages,
 
 ## [Bun](https://bun.sh/docs/bundler)
 
-Bun includes a built-in bundler accessible via the [`Bun.build()`](https://bun.sh/docs/bundler) API. These build scripts are run with `bun run` rather than `tsx`.
+Bun includes a built-in bundler accessible via the [`Bun.build()`](https://bun.sh/docs/bundler) API. It is the simplest setup in this example set, and if you later switch to [`bun build --compile`](https://bun.sh/docs/bundler/executables), Bun can also produce a standalone executable that embeds the runtime. These build scripts are run with `bun run` rather than `tsx`.
 
 ### CJS
 
@@ -76,7 +100,7 @@ Bun includes a built-in bundler accessible via the [`Bun.build()`](https://bun.s
 
 ## [tsdown](https://tsdown.dev/)
 
-tsdown keeps dependencies external by default — it transpiles your code but doesn't inline `node_modules` packages into the bundle. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
+tsdown sits somewhere between bundling and plain transpilation. It still uses a bundler-style pipeline, so you get tree-shaking and related optimizations, but it keeps dependencies external by default instead of inlining `node_modules` into a single file. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
 
 ### CJS
 

--- a/examples/bundling/content.md
+++ b/examples/bundling/content.md
@@ -24,7 +24,7 @@ esbuild activates the `"import"` export condition whenever source code uses `imp
 
 The fix is simple: use TypeScript's `import = require(...)` syntax for the esbuild CJS entry point. This tells esbuild to resolve the `"require"` export condition instead:
 
-<%= region('cli-esbuild-cjs.ts', 'import') %>
+<%= file('cli-esbuild-cjs.ts').region('import') %>
 
 With that change, no plugins or configuration tweaks are needed:
 

--- a/examples/bundling/content.md
+++ b/examples/bundling/content.md
@@ -4,21 +4,15 @@ Bundling is **not required** to distribute a cli-forge CLI. You can publish your
 
 That said, bundling can be useful when you want a single portable file, faster cold starts, or when embedding a CLI inside a larger tool.
 
-## ESM output
+## Shared CLI source
 
-ESM bundles work out of the box with every bundler tested — no workarounds needed:
+All builds (except esbuild CJS) use this shared entry point:
 
-<%= file('esm/run-esbuild.sh') %>
-<%= file('esm/run-rollup.sh') %>
-<%= file('esm/run-rolldown.sh') %>
-<%= file('esm/run-tsdown.sh') %>
-<%= file('esm/run-bun.sh') %>
+<%= file('cli.ts') %>
 
-## CJS output
+## esbuild
 
-Most bundlers handle CJS output correctly. The one exception is **esbuild**, which requires a small change to how you import cli-forge.
-
-### esbuild gotcha
+### CJS
 
 esbuild activates the `"import"` export condition whenever source code uses `import ... from` syntax — **regardless of the output format**. This means even with `format: 'cjs'` and `platform: 'node'`, esbuild resolves the ESM entry from dual-format packages. If that entry contains `import.meta` (valid in ESM, undefined in CJS), the bundle crashes at runtime.
 
@@ -31,31 +25,59 @@ With that change, no plugins or configuration tweaks are needed:
 <%= file('cjs/run-esbuild.sh') %>
 <%= file('cjs/esbuild.ts') %>
 
-### Rollup, Rolldown, tsdown, and Bun
+### ESM
 
-These bundlers resolve the correct entry for each output format automatically. Standard `import ... from` syntax works:
+ESM bundles work out of the box — no workarounds needed:
+
+<%= file('esm/run-esbuild.sh') %>
+<%= file('esm/esbuild.ts') %>
+
+## Rollup
+
+Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages, so it uses a config file.
+
+### CJS
 
 <%= file('cjs/run-rollup.sh') %>
-<%= file('cjs/run-rolldown.sh') %>
-<%= file('cjs/run-tsdown.sh') %>
-<%= file('cjs/run-bun.sh') %>
-
-Note that **tsdown** keeps dependencies external by default — it transpiles your code but doesn't inline `node_modules` packages into the bundle. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
-
-## Build configs
-
-Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages, so it uses a config file:
-
 <%= file('cjs/rollup.config.mjs') %>
 
-esbuild, rolldown, and bun use small per-format build scripts. Here are the ESM variants (CJS is identical except for the format and output path):
+### ESM
 
-<%= file('esm/esbuild.ts') %>
+<%= file('esm/run-rollup.sh') %>
+<%= file('esm/rollup.config.mjs') %>
+
+## Rolldown
+
+### CJS
+
+<%= file('cjs/run-rolldown.sh') %>
+<%= file('cjs/rolldown.ts') %>
+
+### ESM
+
+<%= file('esm/run-rolldown.sh') %>
 <%= file('esm/rolldown.ts') %>
+
+## Bun
+
+### CJS
+
+<%= file('cjs/run-bun.sh') %>
+<%= file('cjs/bun.ts') %>
+
+### ESM
+
+<%= file('esm/run-bun.sh') %>
 <%= file('esm/bun.ts') %>
 
-## Shared CLI source
+## tsdown
 
-All builds (except esbuild CJS) use this shared entry point:
+tsdown keeps dependencies external by default — it transpiles your code but doesn't inline `node_modules` packages into the bundle. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
 
-<%= file('cli.ts') %>
+### CJS
+
+<%= file('cjs/run-tsdown.sh') %>
+
+### ESM
+
+<%= file('esm/run-tsdown.sh') %>

--- a/examples/bundling/content.md
+++ b/examples/bundling/content.md
@@ -1,0 +1,61 @@
+## Do I need to bundle?
+
+Bundling is **not required** to distribute a cli-forge CLI. You can publish your TypeScript source and let consumers run it with `tsx`, or compile with `tsc` and ship the JavaScript directly. Node.js handles `cli-forge`'s dual-format exports automatically at runtime.
+
+That said, bundling can be useful when you want a single portable file, faster cold starts, or when embedding a CLI inside a larger tool.
+
+## ESM output
+
+ESM bundles work out of the box with every bundler tested — no workarounds needed:
+
+<%= file('esm/run-esbuild.sh') %>
+<%= file('esm/run-rollup.sh') %>
+<%= file('esm/run-rolldown.sh') %>
+<%= file('esm/run-tsdown.sh') %>
+<%= file('esm/run-bun.sh') %>
+
+## CJS output
+
+Most bundlers handle CJS output correctly. The one exception is **esbuild**, which requires a small change to how you import cli-forge.
+
+### esbuild gotcha
+
+esbuild activates the `"import"` export condition whenever source code uses `import ... from` syntax — **regardless of the output format**. This means even with `format: 'cjs'` and `platform: 'node'`, esbuild resolves the ESM entry from dual-format packages. If that entry contains `import.meta` (valid in ESM, undefined in CJS), the bundle crashes at runtime.
+
+The fix is simple: use TypeScript's `import = require(...)` syntax for the esbuild CJS entry point. This tells esbuild to resolve the `"require"` export condition instead:
+
+<%= region('cli-esbuild-cjs.ts', 'import') %>
+
+With that change, no plugins or configuration tweaks are needed:
+
+<%= file('cjs/run-esbuild.sh') %>
+<%= file('cjs/esbuild.ts') %>
+
+### Rollup, Rolldown, tsdown, and Bun
+
+These bundlers resolve the correct entry for each output format automatically. Standard `import ... from` syntax works:
+
+<%= file('cjs/run-rollup.sh') %>
+<%= file('cjs/run-rolldown.sh') %>
+<%= file('cjs/run-tsdown.sh') %>
+<%= file('cjs/run-bun.sh') %>
+
+Note that **tsdown** keeps dependencies external by default — it transpiles your code but doesn't inline `node_modules` packages into the bundle. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
+
+## Build configs
+
+Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages, so it uses a config file:
+
+<%= file('cjs/rollup.config.mjs') %>
+
+esbuild, rolldown, and bun use small per-format build scripts. Here are the ESM variants (CJS is identical except for the format and output path):
+
+<%= file('esm/esbuild.ts') %>
+<%= file('esm/rolldown.ts') %>
+<%= file('esm/bun.ts') %>
+
+## Shared CLI source
+
+All builds (except esbuild CJS) use this shared entry point:
+
+<%= file('cli.ts') %>

--- a/examples/bundling/content.md
+++ b/examples/bundling/content.md
@@ -10,7 +10,7 @@ All builds (except esbuild CJS) use this shared entry point:
 
 <%= file('cli.ts') %>
 
-## esbuild
+## [esbuild](https://esbuild.github.io/)
 
 ### CJS
 
@@ -32,7 +32,7 @@ ESM bundles work out of the box — no workarounds needed:
 <%= file('esm/run-esbuild.sh') %>
 <%= file('esm/esbuild.ts') %>
 
-## Rollup
+## [Rollup](https://rollupjs.org/)
 
 Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages, so it uses a config file.
 
@@ -46,7 +46,9 @@ Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages,
 <%= file('esm/run-rollup.sh') %>
 <%= file('esm/rollup.config.mjs') %>
 
-## Rolldown
+## [Rolldown](https://rolldown.rs/)
+
+[Rolldown](https://rolldown.rs/) is a Rust-based bundler designed as a drop-in replacement for Rollup with better performance. It uses a JavaScript API similar to Rollup's.
 
 ### CJS
 
@@ -58,7 +60,9 @@ Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages,
 <%= file('esm/run-rolldown.sh') %>
 <%= file('esm/rolldown.ts') %>
 
-## Bun
+## [Bun](https://bun.sh/docs/bundler)
+
+Bun includes a built-in bundler accessible via the [`Bun.build()`](https://bun.sh/docs/bundler) API. These build scripts are run with `bun run` rather than `tsx`.
 
 ### CJS
 
@@ -70,7 +74,7 @@ Rollup requires `@rollup/plugin-node-resolve` to bundle `node_modules` packages,
 <%= file('esm/run-bun.sh') %>
 <%= file('esm/bun.ts') %>
 
-## tsdown
+## [tsdown](https://tsdown.dev/)
 
 tsdown keeps dependencies external by default — it transpiles your code but doesn't inline `node_modules` packages into the bundle. This is often the right choice for CLIs that will be installed via npm, since Node.js resolves dependencies at runtime.
 

--- a/examples/bundling/esm/bun.ts
+++ b/examples/bundling/esm/bun.ts
@@ -1,0 +1,7 @@
+// Bun.build() is a Bun-runtime API. This script shells out to
+// the bun CLI to stay compatible with the Node-based test runner.
+import { execSync } from 'child_process';
+
+execSync('bun build cli.ts --outfile dist/esm/bun.mjs --target node --format esm', {
+  stdio: 'inherit',
+});

--- a/examples/bundling/esm/bun.ts
+++ b/examples/bundling/esm/bun.ts
@@ -1,7 +1,12 @@
-// Bun.build() is a Bun-runtime API. This script shells out to
-// the bun CLI to stay compatible with the Node-based test runner.
-import { execSync } from 'child_process';
-
-execSync('bun build cli.ts --outfile dist/esm/bun.mjs --target node --format esm', {
-  stdio: 'inherit',
+const result = await Bun.build({
+  entrypoints: ['cli.ts'],
+  outdir: 'dist/esm',
+  target: 'node',
+  format: 'esm',
+  naming: 'bun.mjs',
 });
+
+if (!result.success) {
+  console.error(result.logs);
+  process.exit(1);
+}

--- a/examples/bundling/esm/esbuild.ts
+++ b/examples/bundling/esm/esbuild.ts
@@ -1,0 +1,11 @@
+import esbuild from 'esbuild';
+
+esbuild.buildSync({
+  entryPoints: ['cli.ts'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'dist/esm/esbuild.mjs',
+  tsconfig: '../tsconfig.json',
+  logLevel: 'warning',
+});

--- a/examples/bundling/esm/rolldown.ts
+++ b/examples/bundling/esm/rolldown.ts
@@ -1,0 +1,15 @@
+import { rolldown } from 'rolldown';
+
+(async () => {
+  const bundle = await rolldown({
+    input: 'cli.ts',
+    platform: 'node',
+    resolve: { tsconfigFilename: '../tsconfig.json' },
+  });
+  await bundle.write({
+    format: 'esm',
+    file: 'dist/esm/rolldown.mjs',
+    codeSplitting: false,
+  });
+  await bundle.close();
+})();

--- a/examples/bundling/esm/rollup.config.mjs
+++ b/examples/bundling/esm/rollup.config.mjs
@@ -1,0 +1,11 @@
+import nodeResolve from '@rollup/plugin-node-resolve';
+
+export default {
+  input: 'cli.ts',
+  plugins: [nodeResolve()],
+  output: {
+    format: 'esm',
+    file: 'dist/esm/rollup.mjs',
+    inlineDynamicImports: true,
+  },
+};

--- a/examples/bundling/esm/run-bun.sh
+++ b/examples/bundling/esm/run-bun.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
-npx tsx esm/bun.ts
+bun run esm/bun.ts

--- a/examples/bundling/esm/run-bun.sh
+++ b/examples/bundling/esm/run-bun.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx esm/bun.ts

--- a/examples/bundling/esm/run-esbuild.sh
+++ b/examples/bundling/esm/run-esbuild.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsx esm/esbuild.ts

--- a/examples/bundling/esm/run-esbuild.sh
+++ b/examples/bundling/esm/run-esbuild.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx esm/esbuild.ts

--- a/examples/bundling/esm/run-rolldown.sh
+++ b/examples/bundling/esm/run-rolldown.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsx esm/rolldown.ts

--- a/examples/bundling/esm/run-rolldown.sh
+++ b/examples/bundling/esm/run-rolldown.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx esm/rolldown.ts

--- a/examples/bundling/esm/run-rollup.sh
+++ b/examples/bundling/esm/run-rollup.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx rollup -c esm/rollup.config.mjs --silent

--- a/examples/bundling/esm/run-rollup.sh
+++ b/examples/bundling/esm/run-rollup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx rollup -c esm/rollup.config.mjs --silent

--- a/examples/bundling/esm/run-tsdown.sh
+++ b/examples/bundling/esm/run-tsdown.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
 npx tsdown cli.ts --format esm --outDir dist/esm --platform node --no-dts

--- a/examples/bundling/esm/run-tsdown.sh
+++ b/examples/bundling/esm/run-tsdown.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsdown cli.ts --format esm --outDir dist/esm --platform node --no-dts

--- a/examples/bundling/meta.yml
+++ b/examples/bundling/meta.yml
@@ -1,0 +1,208 @@
+id: bundling
+title: Bundling
+playground: false
+description: |
+  Validates that cli-forge works correctly when bundled into a single
+  file by popular bundlers, in both ESM and CJS output formats.
+test:
+  # --- CJS ---
+  - name: "cjs/esbuild: bundle"
+    options:
+      command: 'sh cjs/run-esbuild.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "cjs/esbuild: greet"
+    options:
+      command: 'node dist/cjs/esbuild.cjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "cjs/esbuild: add"
+    options:
+      command: 'node dist/cjs/esbuild.cjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "cjs/rollup: bundle"
+    options:
+      command: 'sh cjs/run-rollup.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "cjs/rollup: greet"
+    options:
+      command: 'node dist/cjs/rollup.cjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "cjs/rollup: add"
+    options:
+      command: 'node dist/cjs/rollup.cjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "cjs/rolldown: bundle"
+    options:
+      command: 'sh cjs/run-rolldown.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "cjs/rolldown: greet"
+    options:
+      command: 'node dist/cjs/rolldown.cjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "cjs/rolldown: add"
+    options:
+      command: 'node dist/cjs/rolldown.cjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "cjs/bun: bundle"
+    options:
+      command: 'sh cjs/run-bun.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "cjs/bun: greet"
+    options:
+      command: 'node dist/cjs/bun.cjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "cjs/bun: add"
+    options:
+      command: 'node dist/cjs/bun.cjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "cjs/tsdown: bundle"
+    options:
+      command: 'sh cjs/run-tsdown.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "cjs/tsdown: greet"
+    options:
+      command: 'node dist/cjs/cli.cjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "cjs/tsdown: add"
+    options:
+      command: 'node dist/cjs/cli.cjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  # --- ESM ---
+  - name: "esm/esbuild: bundle"
+    options:
+      command: 'sh esm/run-esbuild.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "esm/esbuild: greet"
+    options:
+      command: 'node dist/esm/esbuild.mjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "esm/esbuild: add"
+    options:
+      command: 'node dist/esm/esbuild.mjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "esm/rollup: bundle"
+    options:
+      command: 'sh esm/run-rollup.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "esm/rollup: greet"
+    options:
+      command: 'node dist/esm/rollup.mjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "esm/rollup: add"
+    options:
+      command: 'node dist/esm/rollup.mjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "esm/rolldown: bundle"
+    options:
+      command: 'sh esm/run-rolldown.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "esm/rolldown: greet"
+    options:
+      command: 'node dist/esm/rolldown.mjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "esm/rolldown: add"
+    options:
+      command: 'node dist/esm/rolldown.mjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "esm/bun: bundle"
+    options:
+      command: 'sh esm/run-bun.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "esm/bun: greet"
+    options:
+      command: 'node dist/esm/bun.mjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "esm/bun: add"
+    options:
+      command: 'node dist/esm/bun.mjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'
+
+  - name: "esm/tsdown: bundle"
+    options:
+      command: 'sh esm/run-tsdown.sh'
+    assertions:
+      exitCode: 0
+
+  - name: "esm/tsdown: greet"
+    options:
+      command: 'node dist/esm/cli.mjs greet --name CLI-Forge'
+    assertions:
+      stdout:
+        contains: 'Hello, CLI-Forge!'
+
+  - name: "esm/tsdown: add"
+    options:
+      command: 'node dist/esm/cli.mjs add --a 2 --b 3'
+    assertions:
+      stdout:
+        contains: '2 + 3 = 5'

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,8 +3,12 @@
   "private": true,
   "dependencies": {
     "@cli-forge/parser": "workspace:*",
+    "@rollup/plugin-node-resolve": "^16.0.0",
     "cli-forge": "workspace:*",
+    "esbuild": "^0.27.0",
     "i18next": "^25.7.3",
+    "rolldown": "^1.0.0-rc.12",
+    "rollup": "^4.0.0",
     "tslib": "catalog:"
   }
 }

--- a/examples/tsconfig.lib.json
+++ b/examples/tsconfig.lib.json
@@ -4,5 +4,6 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["bundling/cjs/bun.ts", "bundling/esm/bun.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,12 +414,24 @@ importers:
       '@cli-forge/parser':
         specifier: workspace:*
         version: link:../packages/parser
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.0
+        version: 16.0.3(rollup@4.60.1)
       cli-forge:
         specifier: workspace:*
         version: link:../packages/cli-forge
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.7
       i18next:
         specifier: ^25.7.3
         version: 25.8.10(typescript@5.9.3)
+      rolldown:
+        specifier: ^1.0.0-rc.12
+        version: 1.0.0-rc.12
+      rollup:
+        specifier: ^4.0.0
+        version: 4.60.1
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
@@ -2296,6 +2308,24 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
+  '@rollup/plugin-node-resolve@16.0.3':
+    resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
@@ -2728,6 +2758,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
   '@types/responselike@1.0.0':
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
@@ -4437,6 +4470,9 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -8717,6 +8753,24 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.11
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.1
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
@@ -9100,6 +9154,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.2': {}
 
   '@types/responselike@1.0.0':
     dependencies:
@@ -11203,6 +11259,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-interactive@1.0.0: {}
+
+  is-module@1.0.0: {}
 
   is-number@7.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add comprehensive bundling example testing cli-forge with 5 bundlers (esbuild, rollup, rolldown, bun, tsdown) in both CJS and ESM output formats
- Document the esbuild CJS gotcha (resolves `"import"` condition regardless of output format) with the `import = require()` workaround
- Bun build scripts use `Bun.build()` API directly, run via `bun run`
- Docs structured per-bundler with CJS/ESM subsections
- Fix docs-site examples caching and prose rendering

## Test plan

- [ ] `nx run e2e:e2e:examples -- --filter bundling` passes all 30 tests (5 bundlers × 2 formats × 3 assertions)
- [ ] `nx build docs-site` generates bundling example page correctly
- [ ] Verify bundled CLIs work: `node dist/cjs/esbuild.cjs greet --name Test`