### PR TITLE
feat(cli-forge): add configOnly option flag for config-only fields

### DIFF
--- a/packages/cli-forge/src/bin/commands/generate-documentation.ts
+++ b/packages/cli-forge/src/bin/commands/generate-documentation.ts
@@ -212,6 +212,41 @@ function generateLlmsTxtContent(
     }
   }
 
+  // Configuration options
+  const configOptionEntries = Object.entries(docs.configurationOptions);
+  if (configOptionEntries.length > 0) {
+    lines.push(`${indent}Configuration Options:`);
+    for (const [, opt] of configOptionEntries) {
+      const typeStr = formatOptionType(opt);
+      const aliasStr = opt.alias?.length
+        ? ` (aliases: ${opt.alias
+            .map((a) => (a.length === 1 ? `-${a}` : `--${a}`))
+            .join(', ')})`
+        : '';
+      const reqStr =
+        opt.required && opt.default === undefined ? ' [required]' : '';
+      const deprecatedStr = opt.deprecated ? ' [deprecated]' : '';
+      lines.push(
+        `${indent}  --${opt.key}${aliasStr} <${typeStr}>${reqStr}${deprecatedStr}`
+      );
+      if (opt.description) {
+        lines.push(`${indent}    ${opt.description}`);
+      }
+      if (opt.default !== undefined) {
+        lines.push(`${indent}    Default: ${JSON.stringify(opt.default)}`);
+      }
+      if ('choices' in opt && opt.choices) {
+        const choicesList =
+          typeof opt.choices === 'function' ? opt.choices() : opt.choices;
+        lines.push(`${indent}    Valid values: ${choicesList.join(', ')}`);
+      }
+      if ('resolvedEnvKey' in opt && opt.resolvedEnvKey) {
+        lines.push(`${indent}    Env var: ${opt.resolvedEnvKey}`);
+      }
+    }
+    lines.push('');
+  }
+
   // Configuration sources
   if (docs.configurationSources && docs.configurationSources.length > 0) {
     lines.push(`${indent}Configuration:`);
@@ -292,6 +327,11 @@ async function generateMarkdownForSingleCommand(
             group.label,
             md
           )
+        ),
+        getFlagArgsFragment(
+          docs.configurationOptions,
+          'Configuration Options',
+          md
         ),
         getConfigurationSourcesLink(
           docs.configurationSources,

--- a/packages/cli-forge/src/lib/completion.spec.ts
+++ b/packages/cli-forge/src/lib/completion.spec.ts
@@ -60,6 +60,20 @@ describe('shell completion', () => {
     expect(output).toContain('public');
   });
 
+  it('should exclude configOnly options from completions', async () => {
+    const mock = mockConsoleLog();
+    await cli('test')
+      .completion()
+      .option('verbose', { type: 'boolean' })
+      .option('logLevel', { type: 'string', configOnly: true })
+      .command('$0', { handler: () => {} })
+      .forge(['--get-completions']);
+    mock.restore();
+    const output = mock.getOutput();
+    expect(output).toContain('--verbose');
+    expect(output).not.toContain('--logLevel');
+  });
+
   it('should return choices when completing an option value', async () => {
     const mock = mockConsoleLog();
     await cli('test')

--- a/packages/cli-forge/src/lib/documentation.spec.ts
+++ b/packages/cli-forge/src/lib/documentation.spec.ts
@@ -32,6 +32,40 @@ describe('generateDocumentation', () => {
     expect(barDocs?.options?.['b']).toBeUndefined();
   });
 
+  it('should place configOnly options in configurationOptions, not options', () => {
+    const docs = generateDocumentation(
+      cli('test')
+        .option('verbose', { type: 'boolean' })
+        .option('logLevel', {
+          type: 'string',
+          configOnly: true,
+          description: 'Set the log level',
+        }) as unknown as InternalCLI
+    );
+
+    expect(docs.options['verbose']).toBeDefined();
+    expect(docs.options['logLevel']).toBeUndefined();
+
+    expect(docs.configurationOptions['logLevel']).toBeDefined();
+    expect(docs.configurationOptions['logLevel'].description).toBe(
+      'Set the log level'
+    );
+  });
+
+  it('should not include hidden configOnly options in configurationOptions', () => {
+    const docs = generateDocumentation(
+      cli('test')
+        .option('secret', {
+          type: 'string',
+          configOnly: true,
+          hidden: true,
+        }) as unknown as InternalCLI
+    );
+
+    expect(docs.options['secret']).toBeUndefined();
+    expect(docs.configurationOptions['secret']).toBeUndefined();
+  });
+
   it('should not execute command handlers', () => {
     let ran = false;
     generateDocumentation(

--- a/packages/cli-forge/src/lib/documentation.ts
+++ b/packages/cli-forge/src/lib/documentation.ts
@@ -16,6 +16,11 @@ export type Documentation = {
   usage: string;
   examples: string[];
   options: Readonly<Record<string, NormalizedOptionConfig>>;
+  /**
+   * Options marked as `configOnly: true`. These are shown in a separate
+   * "Configuration Options" section rather than the main options list.
+   */
+  configurationOptions: Readonly<Record<string, NormalizedOptionConfig>>;
   positionals: readonly Readonly<NormalizedOptionConfig>[];
   groupedOptions: Array<{
     label: string;
@@ -121,9 +126,18 @@ export function generateDocumentation(
   const envInfo = parser.getEnvInfo();
   const options: Record<string, NormalizedOptionConfig> = Object.fromEntries(
     Object.entries(parser.configuredOptions)
-      .filter(([, c]) => !c.hidden)
+      .filter(([, c]) => !c.hidden && !c.configOnly)
       .map(([k, v]) => [k, normalizeOptionConfigForDocumentation(v, k, envInfo)])
   );
+  const configurationOptions: Record<string, NormalizedOptionConfig> =
+    Object.fromEntries(
+      Object.entries(parser.configuredOptions)
+        .filter(([, c]) => !c.hidden && c.configOnly)
+        .map(([k, v]) => [
+          k,
+          normalizeOptionConfigForDocumentation(v, k, envInfo),
+        ])
+    );
   const positionals = parser.configuredPositionals;
   for (const positional of positionals) {
     delete options[positional.key];
@@ -196,6 +210,7 @@ export function generateDocumentation(
     examples: cli.configuration?.examples ?? [],
     groupedOptions,
     options,
+    configurationOptions,
     positionals,
     subcommands,
   };

--- a/packages/cli-forge/src/lib/format-help.spec.ts
+++ b/packages/cli-forge/src/lib/format-help.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatHelp } from './format-help';
+import cli from './public-api';
+import { InternalCLI } from './internal-cli';
+
+describe('formatHelp', () => {
+  it('should show configOnly options in a separate Configuration Options section', () => {
+    const testCli = cli('test')
+      .option('verbose', { type: 'boolean', description: 'Enable verbose output' })
+      .option('logLevel', {
+        type: 'string',
+        configOnly: true,
+        description: 'Set the log level',
+      }) as unknown as InternalCLI;
+
+    const help = formatHelp(testCli);
+
+    // Regular options section should contain verbose but not logLevel
+    const optionsSection = help.split('Configuration Options:')[0];
+    expect(optionsSection).toContain('--verbose');
+    expect(optionsSection).not.toContain('--logLevel');
+
+    // Configuration Options section should contain logLevel
+    expect(help).toContain('Configuration Options:');
+    expect(help.split('Configuration Options:')[1]).toContain('--logLevel');
+  });
+
+  it('should not show Configuration Options section when no configOnly options exist', () => {
+    const testCli = cli('test')
+      .option('verbose', { type: 'boolean' }) as unknown as InternalCLI;
+
+    const help = formatHelp(testCli);
+    expect(help).not.toContain('Configuration Options:');
+  });
+
+  it('should not show configOnly options that are also hidden', () => {
+    const testCli = cli('test')
+      .option('secret', {
+        type: 'string',
+        configOnly: true,
+        hidden: true,
+        description: 'A hidden config field',
+      }) as unknown as InternalCLI;
+
+    const help = formatHelp(testCli);
+    expect(help).not.toContain('Configuration Options:');
+    expect(help).not.toContain('--secret');
+  });
+});

--- a/packages/cli-forge/src/lib/format-help.ts
+++ b/packages/cli-forge/src/lib/format-help.ts
@@ -62,13 +62,21 @@ export function formatHelp(parentCLI: InternalCLI<any>): string {
   const groupedOptions = parentCLI.getGroupedOptions();
   const nonpositionalOptions = Object.values(
     command.parser.configuredOptions
-  ).filter((c) => !c.positional && !c.hidden);
+  ).filter((c) => !c.positional && !c.hidden && !c.configOnly);
 
   help.push(...getOptionBlock('Options', nonpositionalOptions, command.parser));
 
   for (const { label, keys } of groupedOptions) {
     help.push(...getOptionBlock(label, keys, command.parser));
   }
+
+  const configOnlyOptions = Object.values(
+    command.parser.configuredOptions
+  ).filter((c) => !c.positional && !c.hidden && c.configOnly);
+
+  help.push(
+    ...getOptionBlock('Configuration Options', configOnlyOptions, command.parser)
+  );
 
   if (command.configuration?.examples?.length) {
     help.push('');

--- a/packages/cli-forge/src/lib/resolve-completions.ts
+++ b/packages/cli-forge/src/lib/resolve-completions.ts
@@ -34,6 +34,7 @@ function getDefaultCompletions(
   const seenOptionKeys = new Set<string>();
   for (const [key, config] of Object.entries(configuredOptions)) {
     if (config.hidden) continue;
+    if (config.configOnly) continue;
     if (config.positional) continue;
     // Deduplicate — the parser may register the same option under
     // both its camelCase key and dashed alias.

--- a/packages/parser/src/lib/option-types/common.ts
+++ b/packages/parser/src/lib/option-types/common.ts
@@ -128,6 +128,9 @@ export type CommonOptionConfig<T, TCoerce = T, TChoices = T[]> = {
    * It will also be excluded from shell completions.
    *
    * Unlike `hidden`, config-only options are still documented.
+   *
+   * Note: if both `configOnly` and `group` are set, the option appears
+   * under its group rather than the "Configuration Options" section.
    */
   configOnly?: boolean;
 

--- a/packages/parser/src/lib/option-types/common.ts
+++ b/packages/parser/src/lib/option-types/common.ts
@@ -122,6 +122,16 @@ export type CommonOptionConfig<T, TCoerce = T, TChoices = T[]> = {
   hidden?: boolean;
 
   /**
+   * If true, this option is presented as a configuration-only field.
+   * It will be shown in a dedicated "Configuration Options" section
+   * in help text and documentation, rather than in the main options list.
+   * It will also be excluded from shell completions.
+   *
+   * Unlike `hidden`, config-only options are still documented.
+   */
+  configOnly?: boolean;
+
+  /**
    * Can be set to group options in help output and generated docs.
    */
   group?: string;

--- a/packages/parser/src/lib/option-types/one-of.ts
+++ b/packages/parser/src/lib/option-types/one-of.ts
@@ -68,6 +68,7 @@ type OneOfTopLevelFields = Pick<
   | 'env'
   | 'required'
   | 'hidden'
+  | 'configOnly'
   | 'group'
   | 'description'
   | 'deprecated'


### PR DESCRIPTION
## Summary

- Adds `configOnly?: boolean` to `CommonOptionConfig` — a new visibility tier between fully visible and `hidden`
- Config-only options appear in a dedicated "Configuration Options" section in `--help` output, generated markdown docs, and llms.txt — but are excluded from the main options list and shell completions
- `hidden: true` takes precedence when both flags are set

## Motivation

Config files can have fields that don't make sense as CLI arguments (e.g. deeply nested settings, environment-specific overrides). Previously the only option was `hidden: true`, which hides from help **and** docs entirely. `configOnly` provides a middle ground: hidden from the main CLI options list, but still documented.

## Changes

| File | Change |
|------|--------|
| `packages/parser/src/lib/option-types/common.ts` | Add `configOnly?: boolean` field |
| `packages/parser/src/lib/option-types/one-of.ts` | Add `configOnly` to `OneOfTopLevelFields` Pick |
| `packages/cli-forge/src/lib/format-help.ts` | Separate "Configuration Options:" section in help |
| `packages/cli-forge/src/lib/resolve-completions.ts` | Exclude configOnly from completions |
| `packages/cli-forge/src/lib/documentation.ts` | Add `configurationOptions` to `Documentation` type |
| `packages/cli-forge/src/bin/commands/generate-documentation.ts` | Render configOnly in markdown and llms.txt |

## Test plan

- [x] `format-help.spec.ts` — 3 new tests (separate section, empty state, hidden interaction)
- [x] `completion.spec.ts` — 1 new test (excluded from completions)
- [x] `documentation.spec.ts` — 2 new tests (split into configurationOptions, hidden interaction)
- [x] All existing tests pass (166 cli-forge, 268 parser)