### PR TITLE
Add handler error propagation and config updateConfig support

### DIFF
--- a/examples/config-patterns/fresh-updater.ts
+++ b/examples/config-patterns/fresh-updater.ts
@@ -3,17 +3,11 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { ConfigurationFiles, cli } from 'cli-forge';
 
-// The updater-function form of updateConfig sees an empty object as the
-// "current" config when the default-path file does not exist yet. Use this
-// pattern when you need to read-modify-write but don't know whether the
-// config already exists.
-//
-// NOTE: the `current` value passed to the updater is derived from whatever
-// providers resolve from the current working directory. When the only file
-// on disk lives at a framework-managed `default` path (outside cwd), the
-// updater will keep seeing `{}` even after a previous write succeeded.
-// For that case, prefer the partial-values form of `updateConfig` — the
-// provider itself merges the partial into the existing file on disk.
+// The updater-function form of `updateConfig` reads the current config
+// from the on-disk file before invoking the callback. On the first run
+// this means the updater sees an empty object (no file exists yet); on
+// subsequent runs it sees the previously persisted state — even when the
+// file lives at a framework-managed `default` path outside cwd.
 const tempDir = mkdtempSync(join(tmpdir(), 'fresh-updater-'));
 const configPath = join(tempDir, 'counter.json');
 
@@ -26,22 +20,26 @@ const app = cli('counter', {
         default: () => configPath,
       }),
   handler: async () => {
-    // Updater form on a fresh file — `current` is {}, so starting values
-    // must come from fallbacks in the user code.
+    // First call — no file exists. The updater gets `{}` as current, so
+    // `config.count` is undefined and we fall back to 0.
     await app.updateConfig((config) => {
       const existing = (config as { count?: number }).count ?? 0;
       config.count = existing + 1;
     });
 
     const first = JSON.parse(readFileSync(configPath, 'utf-8'));
-    console.log(`after updater form count: ${first.count}`);
+    console.log(`first call count: ${first.count}`);
 
-    // Partial-values form — the provider reads the on-disk file and merges,
-    // so this correctly bumps the count from 1 to 2 regardless of cwd.
-    await app.updateConfig({ count: first.count + 1 });
+    // Second call — the file now exists at the default path and the
+    // updater sees the previously persisted value, so this correctly
+    // increments from 1 to 2 without needing any manual plumbing.
+    await app.updateConfig((config) => {
+      const existing = (config as { count?: number }).count ?? 0;
+      config.count = existing + 1;
+    });
 
     const second = JSON.parse(readFileSync(configPath, 'utf-8'));
-    console.log(`after partial form count: ${second.count}`);
+    console.log(`second call count: ${second.count}`);
   },
 });
 

--- a/examples/config-patterns/fresh-updater.ts
+++ b/examples/config-patterns/fresh-updater.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// The updater-function form of updateConfig sees an empty object as the
+// "current" config when the default-path file does not exist yet. Use this
+// pattern when you need to read-modify-write but don't know whether the
+// config already exists.
+//
+// NOTE: the `current` value passed to the updater is derived from whatever
+// providers resolve from the current working directory. When the only file
+// on disk lives at a framework-managed `default` path (outside cwd), the
+// updater will keep seeing `{}` even after a previous write succeeded.
+// For that case, prefer the partial-values form of `updateConfig` — the
+// provider itself merges the partial into the existing file on disk.
+const tempDir = mkdtempSync(join(tmpdir(), 'fresh-updater-'));
+const configPath = join(tempDir, 'counter.json');
+
+const app = cli('counter', {
+  builder: (args) =>
+    args
+      .option('count', { type: 'number', default: 0 })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'counter.json',
+        default: () => configPath,
+      }),
+  handler: async () => {
+    // Updater form on a fresh file — `current` is {}, so starting values
+    // must come from fallbacks in the user code.
+    await app.updateConfig((config) => {
+      const existing = (config as { count?: number }).count ?? 0;
+      config.count = existing + 1;
+    });
+
+    const first = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after updater form count: ${first.count}`);
+
+    // Partial-values form — the provider reads the on-disk file and merges,
+    // so this correctly bumps the count from 1 to 2 regardless of cwd.
+    await app.updateConfig({ count: first.count + 1 });
+
+    const second = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after partial form count: ${second.count}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/init-flow.ts
+++ b/examples/config-patterns/init-flow.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// Simulate a fresh project directory with no config file on disk.
+const tempDir = mkdtempSync(join(tmpdir(), 'init-flow-'));
+const configPath = join(tempDir, 'my-tool.config.json');
+
+// #region init-flow
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .option('lang', { type: 'string', default: 'en' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+        default: () => configPath,
+      }),
+  handler: () => undefined,
+}).command('init', {
+  description: 'Create a fresh config file and then update a value in place',
+  handler: async () => {
+    // First write: no file exists, so the framework falls through to the
+    // `default` path and creates the file.
+    console.log(`before init: exists=${existsSync(configPath)}`);
+    await app.updateConfig({ theme: 'dark', lang: 'fr' });
+
+    const afterInit = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`after init: theme=${afterInit.theme} lang=${afterInit.lang}`);
+
+    // Second write: the file now resolves on disk, so the update is merged
+    // into the resolved file rather than going through the default path.
+    // Only `theme` is passed so `lang` is preserved.
+    await app.updateConfig({ theme: 'system' });
+
+    const afterUpdate = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(
+      `after update: theme=${afterUpdate.theme} lang=${afterUpdate.lang}`
+    );
+  },
+});
+// #endregion init-flow
+
+(async () => {
+  try {
+    await app.forge(['init']);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/init-flow.ts
+++ b/examples/config-patterns/init-flow.ts
@@ -19,19 +19,21 @@ const app = cli('my-tool', {
       }),
   handler: () => undefined,
 }).command('init', {
-  description: 'Create a fresh config file and then update a value in place',
+  description:
+    'Bootstrap a fresh config file and then update a value in place',
   handler: async () => {
-    // First write: no file exists, so the framework falls through to the
-    // `default` path and creates the file.
+    // First write: no file exists on disk, so the framework falls through
+    // to the `default` path and creates the file.
     console.log(`before init: exists=${existsSync(configPath)}`);
     await app.updateConfig({ theme: 'dark', lang: 'fr' });
 
     const afterInit = JSON.parse(readFileSync(configPath, 'utf-8'));
     console.log(`after init: theme=${afterInit.theme} lang=${afterInit.lang}`);
 
-    // Second write: the file now resolves on disk, so the update is merged
-    // into the resolved file rather than going through the default path.
-    // Only `theme` is passed so `lang` is preserved.
+    // Second write: the file now exists at the default path. The JSON
+    // file loader reads the existing content from that path, merges the
+    // partial update in, and writes it back — so `lang` is preserved
+    // without having to pass it through the update.
     await app.updateConfig({ theme: 'system' });
 
     const afterUpdate = JSON.parse(readFileSync(configPath, 'utf-8'));

--- a/examples/config-patterns/meta.yml
+++ b/examples/config-patterns/meta.yml
@@ -35,3 +35,69 @@ test:
     assertions:
       stdout:
         contains: 'howdy, partner!'
+  - name: 'init flow: first write creates file at default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'before init: exists=false'
+  - name: 'init flow: first write writes dark/fr'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'after init: theme=dark lang=fr'
+  - name: 'init flow: second write preserves lang and updates theme'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json init-flow.ts'
+    assertions:
+      stdout:
+        contains: 'after update: theme=system lang=fr'
+  - name: 'nested-default: default path file does not exist before write'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'before: exists=false'
+  - name: 'nested-default: framework creates intermediate directories and writes file'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'after: exists=true'
+  - name: 'nested-default: written file contains the updated value'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json nested-default.ts'
+    assertions:
+      stdout:
+        contains: 'written theme: dark'
+  - name: 'fresh-updater: updater form writes initial value to default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
+    assertions:
+      stdout:
+        contains: 'after updater form count: 1'
+  - name: 'fresh-updater: partial form merges with on-disk file'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
+    assertions:
+      stdout:
+        contains: 'after partial form count: 2'
+  - name: 'multi-provider-fallback: fallback provider default path is used when nothing resolves'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'before: user exists=false'
+  - name: 'multi-provider-fallback: fallback provider writes to its default path'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'after: user exists=true'
+  - name: 'multi-provider-fallback: written file has the updated theme'
+    options:
+      command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'
+    assertions:
+      stdout:
+        contains: 'user config theme: dark'

--- a/examples/config-patterns/meta.yml
+++ b/examples/config-patterns/meta.yml
@@ -71,18 +71,18 @@ test:
     assertions:
       stdout:
         contains: 'written theme: dark'
-  - name: 'fresh-updater: updater form writes initial value to default path'
+  - name: 'fresh-updater: first call writes initial value via default path'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
     assertions:
       stdout:
-        contains: 'after updater form count: 1'
-  - name: 'fresh-updater: partial form merges with on-disk file'
+        contains: 'first call count: 1'
+  - name: 'fresh-updater: second call reads previously persisted value from default path'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json fresh-updater.ts'
     assertions:
       stdout:
-        contains: 'after partial form count: 2'
+        contains: 'second call count: 2'
   - name: 'multi-provider-fallback: fallback provider default path is used when nothing resolves'
     options:
       command: 'npx tsx --no-cache --tsconfig ../tsconfig.json multi-provider-fallback.ts'

--- a/examples/config-patterns/multi-provider-fallback.ts
+++ b/examples/config-patterns/multi-provider-fallback.ts
@@ -1,0 +1,41 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// Demonstrates multi-provider fallback: a project config provider is
+// preferred but has no file on disk, so the user-level fallback provider's
+// `default` path is used for writes instead.
+const tempDir = mkdtempSync(join(tmpdir(), 'multi-provider-fallback-'));
+const userConfigPath = join(tempDir, '.config', 'my-tool', 'config.json');
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      // Project-level — preferred, but not present on disk in this example.
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.config.json',
+      })
+      // User-level fallback — has a default path so init-style writes work.
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'my-tool.json',
+        default: () => userConfigPath,
+      }),
+  handler: async () => {
+    console.log(`before: user exists=${existsSync(userConfigPath)}`);
+    await app.updateConfig({ theme: 'dark' });
+
+    console.log(`after: user exists=${existsSync(userConfigPath)}`);
+    const written = JSON.parse(readFileSync(userConfigPath, 'utf-8'));
+    console.log(`user config theme: ${written.theme}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/nested-default.ts
+++ b/examples/config-patterns/nested-default.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigurationFiles, cli } from 'cli-forge';
+
+// A "user-level" default that lives several directories deep — the framework
+// must create the intermediate folders (like `mkdir -p`) before writing.
+const baseDir = mkdtempSync(join(tmpdir(), 'nested-default-'));
+const configPath = join(baseDir, '.config', 'my-tool', 'settings.json');
+
+const app = cli('my-tool', {
+  builder: (args) =>
+    args
+      .option('theme', { type: 'string', default: 'light' })
+      .config(ConfigurationFiles.JsonFileConfigLoader, {
+        filename: 'settings.json',
+        default: () => configPath,
+      }),
+  handler: async () => {
+    console.log(`before: exists=${existsSync(configPath)}`);
+    await app.updateConfig({ theme: 'dark' });
+
+    console.log(`after: exists=${existsSync(configPath)}`);
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    console.log(`written theme: ${written.theme}`);
+  },
+});
+
+(async () => {
+  try {
+    await app.forge([]);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+})();

--- a/examples/config-patterns/nested-default.ts
+++ b/examples/config-patterns/nested-default.ts
@@ -1,10 +1,16 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { ConfigurationFiles, cli } from 'cli-forge';
+import { ConfigurationProviders, cli } from 'cli-forge';
 
 // A "user-level" default that lives several directories deep — the framework
 // must create the intermediate folders (like `mkdir -p`) before writing.
+//
+// This example uses the `.config(provider, { default })` overload with the
+// convenience `ConfigurationProviders.JsonFile` factory. The class-based
+// `.config(ConfigurationFiles.JsonFileConfigLoader, { filename, default })`
+// form also works, but the factory style is shorter when you don't need a
+// custom transform.
 const baseDir = mkdtempSync(join(tmpdir(), 'nested-default-'));
 const configPath = join(baseDir, '.config', 'my-tool', 'settings.json');
 
@@ -12,8 +18,7 @@ const app = cli('my-tool', {
   builder: (args) =>
     args
       .option('theme', { type: 'string', default: 'light' })
-      .config(ConfigurationFiles.JsonFileConfigLoader, {
-        filename: 'settings.json',
+      .config(ConfigurationProviders.JsonFile('settings.json'), {
         default: () => configPath,
       }),
   handler: async () => {

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -9,7 +9,7 @@ import {
   setFileSystemProvider,
 } from '@cli-forge/parser';
 import { InternalCLI } from './internal-cli';
-import { cli } from './public-api';
+import { cli, HandlerExecutionError } from './public-api';
 import type { PromptProvider } from './prompt-types';
 
 const ORIGINAL_CONSOLE_LOG = console.log;
@@ -286,14 +286,20 @@ describe('cliForge', () => {
 
   it('should print help if command throws', async () => {
     const { getOutput } = mockConsoleLog();
-    await cli('test')
-      .command('foo', {
-        builder: (argv) => argv.option('bar', { type: 'string' }),
-        handler: () => {
-          throw new Error('test');
-        },
-      })
-      .forge(['foo']);
+    // Handler errors now propagate through the registered error handler
+    // chain (matching init hook / parse error behavior) and re-throw after
+    // all handlers run, so callers can observe the failure. The default
+    // catch-all handler still prints the help text and sets exitCode=1.
+    await expect(
+      cli('test')
+        .command('foo', {
+          builder: (argv) => argv.option('bar', { type: 'string' }),
+          handler: () => {
+            throw new Error('test');
+          },
+        })
+        .forge(['foo'])
+    ).rejects.toThrow(/Error executing handler for "test foo"/);
     expect(getOutput()).toMatchInlineSnapshot(`
       "Usage: test foo
 
@@ -303,6 +309,132 @@ describe('cliForge', () => {
         --bar    "
     `);
     expect(process.exitCode).toBe(1);
+  });
+
+  describe('handler error propagation', () => {
+    const swallowStderr = () => {
+      const original = console.error;
+      console.error = () => undefined;
+      return () => {
+        console.error = original;
+      };
+    };
+
+    it('wraps handler errors in HandlerExecutionError with the original as cause', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      const original = new Error('underlying failure');
+      try {
+        await cli('app')
+          .command('run', {
+            handler: () => {
+              throw original;
+            },
+          })
+          .forge(['run']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HandlerExecutionError);
+        expect((e as HandlerExecutionError).command).toBe('app run');
+        expect((e as HandlerExecutionError).cause).toBe(original);
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('routes handler errors through custom errorHandler before re-throwing', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      let seen: unknown;
+      try {
+        await cli('app')
+          .errorHandler((e) => {
+            seen = e;
+          })
+          .command('run', {
+            handler: () => {
+              throw new Error('kaboom');
+            },
+          })
+          .forge(['run']);
+      } catch {
+        // withErrorHandlers re-throws after handlers run
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+      expect(seen).toBeInstanceOf(HandlerExecutionError);
+      expect(((seen as HandlerExecutionError).cause as Error).message).toBe(
+        'kaboom'
+      );
+    });
+
+    it('preserves async handler rejections', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('run', {
+            handler: async () => {
+              await Promise.resolve();
+              throw new Error('async kaboom');
+            },
+          })
+          .forge(['run']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect(e).toBeInstanceOf(HandlerExecutionError);
+        expect(((e as HandlerExecutionError).cause as Error).message).toBe(
+          'async kaboom'
+        );
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('reports the full subcommand path on nested handler failures', async () => {
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('build', {
+            builder: (cmd) =>
+              cmd.command('release', {
+                handler: () => {
+                  throw new Error('release failed');
+                },
+              }),
+            handler: () => undefined,
+          })
+          .forge(['build', 'release']);
+        expect.fail('forge() should have rejected');
+      } catch (e) {
+        expect((e as HandlerExecutionError).command).toBe('app build release');
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
+
+    it('does not wrap framework "missing command" diagnostics', async () => {
+      // demandCommand is a user-facing prompt ("you forgot to specify a
+      // command"), not a handler failure. It should still resolve
+      // gracefully (print help + exitCode) rather than rejecting.
+      const { restore: restoreLog } = mockConsoleLog();
+      const restoreErr = swallowStderr();
+      try {
+        await cli('app')
+          .command('run', { handler: () => undefined })
+          .demandCommand()
+          .forge([]);
+        expect(process.exitCode).toBe(1);
+      } finally {
+        restoreErr();
+        restoreLog();
+      }
+    });
   });
 
   it('should support subcommands with positional args', async () => {

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -1,4 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ConfigurationFiles,
+  MemoryEnvironmentProvider,
+  MemoryFileSystemProvider,
+  getEnvironmentProvider,
+  getFileSystemProvider,
+  setEnvironmentProvider,
+  setFileSystemProvider,
+} from '@cli-forge/parser';
 import { InternalCLI } from './internal-cli';
 import { cli } from './public-api';
 import type { PromptProvider } from './prompt-types';
@@ -1722,6 +1731,184 @@ describe('cliForge', () => {
       expect(handlerArgs.name).toBe('prompted-name');
       expect(handlerArgs.port).toBe(42);
       expect(handlerArgs.verbose).toBe(false); // default, not prompted
+    });
+  });
+
+  describe('updateConfig', () => {
+    let originalEnv: ReturnType<typeof getEnvironmentProvider>;
+    let originalFs: ReturnType<typeof getFileSystemProvider>;
+    let fs: MemoryFileSystemProvider;
+
+    beforeEach(() => {
+      originalEnv = getEnvironmentProvider();
+      originalFs = getFileSystemProvider();
+      fs = new MemoryFileSystemProvider();
+      setEnvironmentProvider(
+        new MemoryEnvironmentProvider({ cwd: '/root' })
+      );
+      setFileSystemProvider(fs);
+    });
+
+    afterEach(() => {
+      setEnvironmentProvider(originalEnv);
+      setFileSystemProvider(originalFs);
+    });
+
+    // These tests exercise the `app.updateConfig()` flow the way real users
+    // call it: from inside a command handler, after `forge()` has run the
+    // root builder (which is where config providers get registered).
+
+    it('updates an existing config file resolved from cwd', async () => {
+      fs.writeFileSync(
+        '/root/app.config.json',
+        JSON.stringify({ theme: 'light', lang: 'en' })
+      );
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+        },
+      });
+
+      await app.forge([]);
+
+      const written = JSON.parse(fs.readFileSync('/root/app.config.json'));
+      expect(written).toEqual({ theme: 'dark', lang: 'fr' });
+    });
+
+    it('writes to the default path when no config file exists on disk', async () => {
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(fs.existsSync('/root/app.config.json')).toBe(true);
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        theme: 'dark',
+        lang: 'fr',
+      });
+    });
+
+    it('supports `default` as a lazy function', async () => {
+      let invocations = 0;
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: () => {
+                invocations++;
+                return '/home/user/.config/app/config.json';
+              },
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(invocations).toBe(1);
+      expect(
+        fs.existsSync('/home/user/.config/app/config.json')
+      ).toBe(true);
+    });
+
+    it('falls back to default on first write, then writes back to the resolved file on subsequent updates', async () => {
+      // Two updateConfig calls from the same handler. The first creates the
+      // file at the `default` path; the second should go to the freshly
+      // resolved path rather than re-using targetPath, and must merge with
+      // the existing file contents instead of overwriting them.
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .option('lang', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig({ theme: 'dark', lang: 'fr' });
+          await app.updateConfig({ theme: 'system' });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        theme: 'system',
+        lang: 'fr',
+      });
+    });
+
+    it('supports updater functions with proxy tracking on a fresh default path', async () => {
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('count', { type: 'number', default: 0 })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+              default: '/root/app.config.json',
+            }),
+        handler: async () => {
+          await app.updateConfig((config) => {
+            const prev = (config as { count?: number }).count ?? 0;
+            config.count = prev + 5;
+          });
+        },
+      });
+
+      await app.forge([]);
+
+      expect(JSON.parse(fs.readFileSync('/root/app.config.json'))).toEqual({
+        count: 5,
+      });
+    });
+
+    it('errors clearly when no provider resolves and no default is configured', async () => {
+      // `runCommand` catches handler errors and logs via console.error to
+      // surface them nicely to end users, so we capture the rejection from
+      // inside the handler instead of asserting on `forge()`'s return.
+      let captured: unknown;
+      const app = cli('app', {
+        builder: (args) =>
+          args
+            .option('theme', { type: 'string' })
+            .config(ConfigurationFiles.JsonFileConfigLoader, {
+              filename: 'app.config.json',
+            }),
+        handler: async () => {
+          try {
+            await app.updateConfig({ theme: 'dark' });
+          } catch (e) {
+            captured = e;
+          }
+        },
+      });
+
+      await app.forge([]);
+
+      expect(captured).toBeInstanceOf(Error);
+      expect((captured as Error).message).toMatch(/no provider resolved/);
     });
   });
 });

--- a/packages/cli-forge/src/lib/internal-cli.spec.ts
+++ b/packages/cli-forge/src/lib/internal-cli.spec.ts
@@ -437,6 +437,58 @@ describe('cliForge', () => {
     });
   });
 
+  describe('repeated forge() calls on the same instance', () => {
+    it('resets commandChain between forge() calls so a CLI instance can run multiple commands', async () => {
+      const calls: string[] = [];
+      const app = cli('app')
+        .command('init', {
+          handler: () => {
+            calls.push('init');
+          },
+        })
+        .command('run', {
+          handler: () => {
+            calls.push('run');
+          },
+        });
+
+      await app.forge(['init']);
+      await app.forge(['run']);
+      await app.forge(['init']);
+
+      expect(calls).toEqual(['init', 'run', 'init']);
+    });
+
+    it('resets commandChain even after a prior forge() call threw', async () => {
+      const { restore } = mockConsoleLog();
+      const originalError = console.error;
+      console.error = () => undefined;
+      try {
+        const calls: string[] = [];
+        const app = cli('app')
+          .command('run', {
+            handler: () => {
+              calls.push('run');
+              throw new Error('boom');
+            },
+          })
+          .command('ok', {
+            handler: () => {
+              calls.push('ok');
+            },
+          });
+
+        await expect(app.forge(['run'])).rejects.toThrow();
+        // Second call must not walk a stale chain from the first one.
+        await app.forge(['ok']);
+        expect(calls).toEqual(['run', 'ok']);
+      } finally {
+        console.error = originalError;
+        restore();
+      }
+    });
+  });
+
   it('should support subcommands with positional args', async () => {
     const args = await cli('test')
       .command(

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -1022,6 +1022,10 @@ export class InternalCLI<
   config(
     provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>
   ): CLI<TArgs, THandlerReturn, TChildren, TParent>;
+  config(
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>,
+    options: { default?: ConfigurationFiles.DefaultConfig<string | URL> }
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent>;
   config<
     C extends new (
       opts: any

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -29,6 +29,7 @@ import {
   CLIHandlerContext,
   Command,
   ErrorHandler,
+  HandlerExecutionError,
   SDKCommand,
 } from './public-api';
 import type {
@@ -117,15 +118,32 @@ export class InternalCLI<
 
   private _versionOverride?: string;
 
+  // Default error handler chain. User-registered handlers are prepended via
+  // `errorHandler()` and run first, so these act as fallbacks. Handlers that
+  // don't match the error type should re-throw to pass the error to the next
+  // handler in the chain.
   private registeredErrorHandlers: Array<ErrorHandler> = [
+    // Specific: print parse/validation failures using the familiar format.
     (e: unknown, actions) => {
-      if (e instanceof ValidationFailedError) {
-        this.printHelp();
-        console.log();
-        console.log(e.message);
-        console.log(e.errors.map((e) => `  - ${e.message}`).join('\n'));
-        actions.exit(1);
-      }
+      if (!(e instanceof ValidationFailedError)) throw e;
+      this.printHelp();
+      console.log();
+      console.log(e.message);
+      console.log(e.errors.map((err) => `  - ${err.message}`).join('\n'));
+      actions.exit(1);
+    },
+    // Catch-all: prints the error and help, sets exitCode, and exits. This
+    // preserves the UX previously implemented via a local try/catch in
+    // runCommand, while routing the error through the handler chain so
+    // custom error handlers get a chance to react first.
+    (e: unknown, actions) => {
+      if (typeof process !== 'undefined') process.exitCode = 1;
+      // HandlerExecutionError's toString() already includes the cause chain
+      // on modern Node versions; logging the wrapper gives users the full
+      // context without losing the underlying stack.
+      console.error(e);
+      this.printHelp();
+      actions.exit(1);
     },
   ];
 
@@ -633,75 +651,95 @@ export class InternalCLI<
         middlewares.add(mw);
       }
     }
-    try {
-      if (cmd.requiresCommand) {
-        throw new Error(
+    // "Missing command" is a user-facing prompt (the CLI was invoked
+    // without a command to run), not a programmer error. Print help and
+    // set exitCode rather than propagating through the error-handler
+    // chain, so interactive use and `demandCommand()` stay ergonomic.
+    if (cmd.requiresCommand) {
+      if (typeof process !== 'undefined') process.exitCode = 1;
+      console.error(
+        new Error(
           `${[this.name, ...this.commandChain].join(' ')} requires a command`
-        );
-      }
-      if (cmd.configuration?.handler) {
-        for (const middleware of middlewares) {
-          if (executedMiddleware?.has(middleware)) continue;
-          const middlewareResult = await middleware(args as any);
-          if (
-            middlewareResult !== void 0 &&
-            typeof middlewareResult === 'object'
-          ) {
-            args = middlewareResult as T;
-          }
+        )
+      );
+      this.printHelp();
+      return args;
+    }
+    if (cmd.configuration?.handler) {
+      for (const middleware of middlewares) {
+        if (executedMiddleware?.has(middleware)) continue;
+        const middlewareResult = await middleware(args as any);
+        if (
+          middlewareResult !== void 0 &&
+          typeof middlewareResult === 'object'
+        ) {
+          args = middlewareResult as T;
         }
+      }
+      // Errors thrown from the handler are wrapped in a HandlerExecutionError
+      // so custom error handlers (registered via `.errorHandler()`) can
+      // distinguish them from framework errors. The original error is
+      // preserved on `.cause`. The wrapped error propagates up through
+      // `withErrorHandlers`, which runs the registered handler chain and
+      // then re-throws — matching init hook and parse error behavior.
+      try {
         await cmd.configuration.handler(args, {
           command: cmd as any,
         });
-        return args;
+      } catch (cause) {
+        throw new HandlerExecutionError(
+          [this.name, ...this.commandChain].join(' '),
+          { cause }
+        );
+      }
+      return args;
+    }
+
+    // We can treat a command as a subshell if it has subcommands
+    if (Object.keys(cmd.registeredCommands).length > 0) {
+      if (typeof process === 'undefined' || !process.stdout?.isTTY) {
+        // If we're not in a TTY (or in a browser), we can't run an interactive shell...
+        // Maybe we should warn here?
+      } else if (args.unmatched.length > 0) {
+        // If there are unmatched args, we don't run an interactive shell...
+        // this could represent a user misspelling a subcommand so it gets rather confusing.
+        console.warn(
+          `Warning: Unrecognized command or arguments: ${args.unmatched.join(
+            ' '
+          )}`
+        );
+        cmd.printHelp();
       } else {
-        // We can treat a command as a subshell if it has subcommands
-        if (Object.keys(cmd.registeredCommands).length > 0) {
-          if (typeof process === 'undefined' || !process.stdout?.isTTY) {
-            // If we're not in a TTY (or in a browser), we can't run an interactive shell...
-            // Maybe we should warn here?
-          } else if (args.unmatched.length > 0) {
-            // If there are unmatched args, we don't run an interactive shell...
-            // this could represent a user misspelling a subcommand so it gets rather confusing.
-            console.warn(
-              `Warning: Unrecognized command or arguments: ${args.unmatched.join(
-                ' '
-              )}`
-            );
-            cmd.printHelp();
-          } else {
-            const shellMod = await getInteractiveShellModule();
-            if (!shellMod.INTERACTIVE_SHELL) {
-              const tui = new shellMod.InteractiveShell(
-                this as unknown as InternalCLI<any>,
-                {
-                  prependArgs: originalArgV,
-                }
-              );
-              await new Promise<void>((res) => {
-                ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach((s) =>
-                  process?.on(s, () => {
-                    tui.close();
-                    res();
-                  })
-                );
-              });
+        const shellMod = await getInteractiveShellModule();
+        if (!shellMod.INTERACTIVE_SHELL) {
+          const tui = new shellMod.InteractiveShell(
+            this as unknown as InternalCLI<any>,
+            {
+              prependArgs: originalArgV,
             }
-          }
-        }
-        // No subcommands so subshell doesn't make sense
-        // No handler, so nothing to run
-        else {
-          throw new Error(
-            `${[this.name, ...this.commandChain].join(' ')} is not implemented.`
           );
+          await new Promise<void>((res) => {
+            ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach((s) =>
+              process?.on(s, () => {
+                tui.close();
+                res();
+              })
+            );
+          });
         }
       }
-    } catch (e) {
-      if (typeof process !== 'undefined') process.exitCode = 1;
-      console.error(e);
-      this.printHelp();
+      return args;
     }
+
+    // No handler, no subcommands. Treated as a framework diagnostic, like
+    // `requiresCommand` — print help and set exitCode rather than throwing.
+    if (typeof process !== 'undefined') process.exitCode = 1;
+    console.error(
+      new Error(
+        `${[this.name, ...this.commandChain].join(' ')} is not implemented.`
+      )
+    );
+    this.printHelp();
     return args;
   }
 

--- a/packages/cli-forge/src/lib/internal-cli.ts
+++ b/packages/cli-forge/src/lib/internal-cli.ts
@@ -1097,6 +1097,15 @@ export class InternalCLI<
       let argv: TArgs & { help?: boolean; version?: boolean };
       let validationFailedError: ValidationFailedError<TArgs> | undefined;
 
+      // `commandChain` is mutated during the discovery loop (subcommand
+      // names are pushed as they are matched). Clear it at the start of
+      // every forge() call so a CLI instance can be invoked multiple
+      // times — e.g. in a long-running server or a test that exercises
+      // several command paths — without walking a stale chain on the
+      // second call. Other per-call state (unmatched tokens, parsed
+      // argv) is already local to this closure.
+      this.commandChain = [];
+
       // Run root builder (may register options, init hooks, commands).
       // If the builder came from a $0 alias, skip it here — we defer
       // running it until the discovery loop confirms no explicit

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -410,6 +410,30 @@ export interface CLI<
   ): CLI<TArgs, THandlerReturn, TChildren, TParent>;
 
   /**
+   * Registers a pre-built configuration provider with framework-level
+   * metadata such as `default`. Useful with convenience factories like
+   * {@link ConfigurationProviders.JsonFile} that already return a
+   * fully-constructed provider but still need to carry a `default` path
+   * so `updateConfig` can create a config file when none exists.
+   *
+   * @example
+   * ```ts
+   * cli('my-tool')
+   *   .option('theme', { type: 'string' })
+   *   .config(ConfigurationProviders.JsonFile('my-tool.config.json'), {
+   *     default: () => join(process.cwd(), 'my-tool.config.json'),
+   *   });
+   * ```
+   *
+   * @param provider The configuration provider to register.
+   * @param options Framework-level options (e.g. `default`).
+   */
+  config(
+    provider: ConfigurationFiles.ConfigProviderRegistration<TArgs>,
+    options: { default?: ConfigurationFiles.DefaultConfig<string | URL> }
+  ): CLI<TArgs, THandlerReturn, TChildren, TParent>;
+
+  /**
    * Registers a configuration provider by class and options.
    * Framework options like `default` are extracted and stored as metadata.
    *

--- a/packages/cli-forge/src/lib/public-api.ts
+++ b/packages/cli-forge/src/lib/public-api.ts
@@ -1126,6 +1126,47 @@ export type ErrorHandler = (
   }
 ) => void;
 
+/**
+ * Error thrown when a command handler (or middleware running as part of the
+ * same execution phase) throws during `forge()`. The original error is
+ * preserved on the {@link cause} property so custom error handlers can
+ * inspect it, while still being able to distinguish framework-reported
+ * handler failures from other errors via `instanceof HandlerExecutionError`.
+ *
+ * @example
+ * ```ts
+ * cli('app', {
+ *   handler: async () => {
+ *     throw new Error('bad thing');
+ *   },
+ * })
+ *   .errorHandler((e) => {
+ *     if (e instanceof HandlerExecutionError) {
+ *       console.error('command:', e.command);
+ *       console.error('cause:', e.cause);
+ *     }
+ *   })
+ *   .forge();
+ * ```
+ */
+export class HandlerExecutionError extends Error {
+  override name = 'HandlerExecutionError';
+  /** The command path (e.g. `"my-tool build release"`) whose handler threw. */
+  readonly command: string;
+
+  constructor(command: string, options: { cause: unknown }) {
+    const causeMessage =
+      options.cause instanceof Error
+        ? options.cause.message
+        : String(options.cause);
+    super(
+      `Error executing handler for "${command}": ${causeMessage}`,
+      options as ErrorOptions
+    );
+    this.command = command;
+  }
+}
+
 export type UnknownCLI = CLI<ParsedArgs, any, any, any>;
 
 export type MiddlewareFunction<TArgs extends ParsedArgs, TArgs2> = (

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.spec.ts
@@ -669,6 +669,99 @@ describe('AggregateConfigProvider', () => {
 
       expect(targetPaths).toEqual([defaultUrl]);
     });
+
+    it('updater form reads current state from the default-path file when nothing resolves from cwd', async () => {
+      // Simulates the flow: init writes to default path, later call wants
+      // to read-modify-write. Without the fix, the updater sees {}
+      // because load(cwd) finds nothing.
+      let onDisk: Record<string, unknown> = { count: 5 };
+
+      const provider: ConfigurationProvider<any> = {
+        // Never resolves from cwd — config only lives at the default path.
+        resolve: () => undefined,
+        load: (file) => {
+          if (file === '/tmp/default.json') return onDisk as any;
+          return {};
+        },
+        updateConfig: async (updater) => {
+          const next =
+            typeof updater === 'function'
+              ? await (updater as any)(onDisk)
+              : updater;
+          onDisk = next;
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      // Mock existsSync so the fallback path is considered "on disk"
+      const fs = await import('../environment-provider.js');
+      const original = fs.getFileSystemProvider();
+      fs.setFileSystemProvider({
+        ...original,
+        existsSync: (p: string) =>
+          p === '/tmp/default.json' ? true : original.existsSync(p),
+      });
+
+      try {
+        await aggregate.updateConfig((config) => {
+          // Should see the persisted count (5), not undefined
+          (config as any).count = ((config as any).count ?? 0) + 1;
+        });
+      } finally {
+        fs.setFileSystemProvider(original);
+      }
+
+      expect(onDisk).toEqual({ count: 6 });
+    });
+
+    it('updater form strips `extends` from the default-path file when loading current state', async () => {
+      let onDisk: Record<string, unknown> = {
+        extends: './base.json',
+        theme: 'dark',
+      };
+
+      const provider: ConfigurationProvider<any> = {
+        resolve: () => undefined,
+        load: () => onDisk as any,
+        updateConfig: async (updater) => {
+          const next =
+            typeof updater === 'function'
+              ? await (updater as any)(onDisk)
+              : updater;
+          onDisk = next;
+        },
+      };
+
+      const aggregate = new AggregateConfigProvider([
+        { provider, default: '/tmp/default.json' },
+      ]);
+      aggregate.load('/root');
+
+      const fs = await import('../environment-provider.js');
+      const original = fs.getFileSystemProvider();
+      fs.setFileSystemProvider({
+        ...original,
+        existsSync: () => true,
+      });
+
+      let seenExtends: unknown;
+      try {
+        await aggregate.updateConfig((config) => {
+          seenExtends = (config as any).extends;
+          (config as any).theme = 'system';
+        });
+      } finally {
+        fs.setFileSystemProvider(original);
+      }
+
+      // The updater should not see `extends` — it's a loader directive,
+      // not a config value.
+      expect(seenExtends).toBeUndefined();
+    });
   });
 
   describe('integration: multi-provider updateConfig routing', () => {

--- a/packages/parser/src/lib/config-files/aggregate-config-provider.ts
+++ b/packages/parser/src/lib/config-files/aggregate-config-provider.ts
@@ -7,6 +7,19 @@ import {
 import { toFilePath } from './utils.js';
 
 /**
+ * Returns true when an object has no own enumerable properties. Used to
+ * detect "nothing resolved from cwd" in {@link AggregateConfigProvider.updateConfig}
+ * so the updater form can fall back to reading the default-path file.
+ */
+function isEmptyObject(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value as object).length === 0
+  );
+}
+
+/**
  * A leaf ConfigurationProvider with any location type.
  */
 type AnyProvider<T> = ConfigurationProvider<T, any>;
@@ -224,7 +237,7 @@ export class AggregateConfigProvider<T> {
   ): Promise<void> {
     let values: Partial<T>;
     if (typeof valuesOrUpdater === 'function') {
-      values = this.trackUpdates(valuesOrUpdater);
+      values = await this.trackUpdates(valuesOrUpdater);
     } else {
       values = valuesOrUpdater;
     }
@@ -294,15 +307,57 @@ export class AggregateConfigProvider<T> {
   /**
    * Runs an updater function against a proxy of the merged config,
    * returning only the properties that were set during the callback.
+   *
+   * The proxy target is computed from:
+   *
+   * 1. The merged result of {@link load} against the current configuration
+   *    root. This sees any provider whose `resolve()` finds a file.
+   * 2. As a fallback, the default-path file of the first provider with a
+   *    `default` option, if that file exists on disk. This allows
+   *    read-modify-write updaters to see the most recently persisted
+   *    state even when the file lives outside the configuration root
+   *    (e.g. a user-level config in `~/.config/my-tool/config.json`).
+   *
+   * Without (2), a sequence like `init` → write via default path →
+   * later `app.updateConfig(config => config.count + 1)` would always
+   * see `count === undefined` because `load(cwd)` never touches the
+   * default-path file.
    */
-  private trackUpdates(updater: ConfigUpdater<T>): Partial<T> {
+  private async trackUpdates(
+    updater: ConfigUpdater<T>
+  ): Promise<Partial<T>> {
     if (!this.lastConfigurationRoot) {
       throw new Error(
         'Cannot use updater function: config has not been loaded yet. Call load() first.'
       );
     }
     // Re-load to get the current merged config
-    const current = this.load(this.lastConfigurationRoot);
+    let current = this.load(this.lastConfigurationRoot);
+
+    // Nothing resolved from cwd — try the default-path file as a fallback.
+    // This keeps updater-form reads consistent with updateConfig writes
+    // when the only on-disk config lives at a framework-managed default.
+    if (isEmptyObject(current) && this.provenance.size === 0) {
+      const defaultResult = await this.resolveDefaultProvider();
+      if (defaultResult) {
+        const fs = getFileSystemProvider();
+        const path = toFilePath(defaultResult.targetPath);
+        if (fs.existsSync(path)) {
+          try {
+            const loaded = defaultResult.provider.load(path);
+            const { extends: _extendsIgnored, ...rest } = (loaded ?? {}) as {
+              extends?: string;
+            } & T;
+            current = rest as T;
+          } catch {
+            // Failed to read the default-path file — leave `current` as the
+            // empty object that load() returned. The updater will see {}
+            // and can fall back to its own defaults.
+          }
+        }
+      }
+    }
+
     const changes: Partial<T> = {} as Partial<T>;
     const proxy = new Proxy(current as object, {
       set(_target, prop, value) {

--- a/packages/parser/src/lib/config-files/json-file-loader.spec.ts
+++ b/packages/parser/src/lib/config-files/json-file-loader.spec.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   getJsonFileConfigLoader,
   JsonFileConfigLoader,
 } from './json-file-loader.js';
 import { isAggregateConfigProvider } from './aggregate-config-provider.js';
+import {
+  MemoryEnvironmentProvider,
+  MemoryFileSystemProvider,
+  getEnvironmentProvider,
+  getFileSystemProvider,
+  setEnvironmentProvider,
+  setFileSystemProvider,
+} from '../environment-provider.js';
 
 describe('getJsonFileConfigLoader', () => {
   it('should return a ConfigurationProvider for a single filename', () => {
@@ -26,5 +34,185 @@ describe('getJsonFileConfigLoader', () => {
     expect(loaders).toHaveLength(2);
     expect(loaders[0]).toHaveProperty('resolve');
     expect(isAggregateConfigProvider(loaders[0])).toBe(false);
+  });
+});
+
+describe('JsonFileConfigLoader updateConfig', () => {
+  let originalEnv: ReturnType<typeof getEnvironmentProvider>;
+  let originalFs: ReturnType<typeof getFileSystemProvider>;
+  let fs: MemoryFileSystemProvider;
+
+  beforeEach(() => {
+    originalEnv = getEnvironmentProvider();
+    originalFs = getFileSystemProvider();
+    fs = new MemoryFileSystemProvider();
+    setEnvironmentProvider(new MemoryEnvironmentProvider({ cwd: '/root' }));
+    setFileSystemProvider(fs);
+  });
+
+  afterEach(() => {
+    setEnvironmentProvider(originalEnv);
+    setFileSystemProvider(originalFs);
+  });
+
+  it('updates an existing file resolved from cwd', async () => {
+    fs.writeFileSync(
+      '/root/app.config.json',
+      JSON.stringify({ theme: 'light', lang: 'en' })
+    );
+    const loader = new JsonFileConfigLoader<{ theme: string; lang: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!({ theme: 'dark', lang: 'fr' });
+
+    const written = JSON.parse(fs.readFileSync('/root/app.config.json'));
+    expect(written).toEqual({ theme: 'dark', lang: 'fr' });
+  });
+
+  it('creates a new file at targetPath when none exists', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    expect(fs.existsSync('/fresh/app.config.json')).toBe(true);
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('passes an empty object to the updater when creating a fresh file at targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ count: number; name: string }>({
+      filename: 'app.config.json',
+    });
+
+    let receivedCurrent: any;
+    await loader.updateConfig!(
+      (current) => {
+        receivedCurrent = current;
+        return { count: 1, name: 'seeded' };
+      },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    expect(receivedCurrent).toEqual({});
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      count: 1,
+      name: 'seeded',
+    });
+  });
+
+  it('creates parent directories when targetPath points into a nested folder', async () => {
+    let recursiveRequested = false;
+    const delegate = fs;
+    setFileSystemProvider({
+      ...delegate,
+      existsSync: (p) => delegate.existsSync(p),
+      readFileSync: (p) => delegate.readFileSync(p),
+      writeFileSync: (p, d) => delegate.writeFileSync(p, d),
+      writeFile: (p, d) => delegate.writeFile(p, d),
+      appendFileSync: (p, d) => delegate.appendFileSync(p, d),
+      readdirSync: (p) => delegate.readdirSync(p),
+      mkdirSync: (dir, options) => {
+        if (options?.recursive) recursiveRequested = true;
+        delegate.mkdirSync(dir, options);
+      },
+      join: (...p) => delegate.join(...p),
+      resolve: (...p) => delegate.resolve(...p),
+      dirname: (p) => delegate.dirname(p),
+      basename: (p) => delegate.basename(p),
+    });
+
+    const loader = new JsonFileConfigLoader<{ port: number }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { port: 3000 },
+      { targetPath: '/home/user/.config/my-tool/app.config.json' }
+    );
+
+    expect(recursiveRequested).toBe(true);
+  });
+
+  it('prefers resolved file over targetPath when the file already exists there', async () => {
+    fs.writeFileSync(
+      '/fresh/app.config.json',
+      JSON.stringify({ theme: 'light' })
+    );
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/app.config.json' }
+    );
+
+    // File exists at targetPath so its contents are merged with the update
+    expect(JSON.parse(fs.readFileSync('/fresh/app.config.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('supports URL as targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: new URL('file:///fresh/via-url.json') }
+    );
+
+    expect(fs.existsSync('/fresh/via-url.json')).toBe(true);
+    expect(JSON.parse(fs.readFileSync('/fresh/via-url.json'))).toEqual({
+      theme: 'dark',
+    });
+  });
+
+  it('throws when no file resolves and no targetPath is provided', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+    });
+
+    await expect(loader.updateConfig!({ theme: 'dark' })).rejects.toThrow(
+      /Could not resolve configuration file/
+    );
+  });
+
+  it('throws when transform is used without writeTransform', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+      transform: (json) => json.section,
+    });
+
+    await expect(
+      loader.updateConfig!(
+        { theme: 'dark' },
+        { targetPath: '/fresh/app.config.json' }
+      )
+    ).rejects.toThrow(/write transform/);
+  });
+
+  it('applies writeTransform when the file is created at targetPath', async () => {
+    const loader = new JsonFileConfigLoader<{ theme: string }>({
+      filename: 'app.config.json',
+      transform: (json) => json.section ?? {},
+      writeTransform: (json, config) => ({ ...json, section: config }),
+    });
+
+    await loader.updateConfig!(
+      { theme: 'dark' },
+      { targetPath: '/fresh/wrapped.json' }
+    );
+
+    const written = JSON.parse(fs.readFileSync('/fresh/wrapped.json'));
+    expect(written).toEqual({ section: { theme: 'dark' } });
   });
 });

--- a/packages/parser/src/lib/parser.spec.ts
+++ b/packages/parser/src/lib/parser.spec.ts
@@ -1318,6 +1318,35 @@ describe('parser', () => {
         .parse([])
     ).toEqual({ foo: 'hello', bar: 42, unmatched: [] });
   });
+
+  it('should accept a pre-built provider with `default` metadata via the (provider, options) overload', async () => {
+    const writes: Array<{ next: any; targetPath?: string | URL }> = [];
+    const provider: ConfigurationProvider<any> = {
+      // Never resolves from cwd — forces the default fallback path.
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function' ? await (updater as any)({}) : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+      },
+    };
+
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .config(provider, { default: '/new/home/config.json' });
+
+    // Still parses successfully (no provider resolved, no values).
+    expect(p.parse([])).toEqual({ unmatched: [] });
+
+    // updateConfig falls through to the default path attached via the
+    // new overload.
+    await p.updateConfig({ foo: 'hello' });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ foo: 'hello' });
+    expect(writes[0].targetPath).toBe('/new/home/config.json');
+  });
 });
 
 describe('parser.updateConfig', () => {

--- a/packages/parser/src/lib/parser.spec.ts
+++ b/packages/parser/src/lib/parser.spec.ts
@@ -1320,6 +1320,200 @@ describe('parser', () => {
   });
 });
 
+describe('parser.updateConfig', () => {
+  function makeUpdatableProvider() {
+    const writes: any[] = [];
+    let current: Record<string, any> = {};
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => '/root/.config.json',
+      load: () => current,
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)(current)
+            : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+        current = next;
+      },
+    };
+    return { provider, writes, getCurrent: () => current };
+  }
+
+  it('should route partial updates to the owning provider before parse runs', async () => {
+    const { provider, writes } = makeUpdatableProvider();
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .option('bar', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig({ foo: 'hello', bar: 7 });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ foo: 'hello', bar: 7 });
+  });
+
+  it('should reflect updated values when parsing after updateConfig', async () => {
+    const { provider } = makeUpdatableProvider();
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .option('bar', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig({ foo: 'hello', bar: 7 });
+
+    expect(p.parse([])).toEqual({ foo: 'hello', bar: 7, unmatched: [] });
+  });
+
+  it('should fall through to the default target path when no provider resolves', async () => {
+    const writes: any[] = [];
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (updater, options) => {
+        const next =
+          typeof updater === 'function' ? await (updater as any)({}) : updater;
+        writes.push({ next, targetPath: options?.targetPath });
+      },
+    };
+
+    class JsonLoader {
+      constructor(_opts: { filename: string }) {
+        return provider;
+      }
+    }
+
+    const p = parser()
+      .option('theme', { type: 'string' })
+      .option('lang', { type: 'string' })
+      .config(JsonLoader as any, {
+        filename: 'my-tool.config.json',
+        default: '/new/home/my-tool.config.json',
+      });
+
+    await p.updateConfig({ theme: 'dark', lang: 'fr' });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].next).toEqual({ theme: 'dark', lang: 'fr' });
+    expect(writes[0].targetPath).toBe('/new/home/my-tool.config.json');
+  });
+
+  it('should support lazy default functions returning a target path', async () => {
+    const writes: any[] = [];
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async (_updater, options) => {
+        writes.push(options?.targetPath);
+      },
+    };
+
+    class JsonLoader {
+      constructor(_opts: { filename: string }) {
+        return provider;
+      }
+    }
+
+    let callCount = 0;
+    const p = parser()
+      .option('key', { type: 'string' })
+      .config(JsonLoader as any, {
+        filename: 'my.json',
+        default: () => {
+          callCount++;
+          return '/fresh/my.json';
+        },
+      });
+
+    await p.updateConfig({ key: 'value' });
+
+    expect(callCount).toBe(1);
+    expect(writes).toEqual(['/fresh/my.json']);
+  });
+
+  it('should throw a descriptive error when no provider resolves and no default is configured', async () => {
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => undefined,
+      load: () => ({}),
+      updateConfig: async () => {},
+    };
+
+    const p = parser()
+      .option('foo', { type: 'string' })
+      .config(provider);
+
+    await expect(p.updateConfig({ foo: 'bar' })).rejects.toThrow(
+      /no provider resolved/
+    );
+  });
+
+  it('should route each key to its owning provider across multiple providers', async () => {
+    const writesA: any[] = [];
+    const writesB: any[] = [];
+    const providerA: ConfigurationProvider<any> = {
+      resolve: () => '/root/.a',
+      load: () => ({ alpha: 'a-value' }),
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)({ alpha: 'a-value' })
+            : updater;
+        writesA.push(next);
+      },
+    };
+    const providerB: ConfigurationProvider<any> = {
+      resolve: () => '/root/.b',
+      load: () => ({ beta: 'b-value' }),
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)({ beta: 'b-value' })
+            : updater;
+        writesB.push(next);
+      },
+    };
+
+    const p = parser()
+      .option('alpha', { type: 'string' })
+      .option('beta', { type: 'string' })
+      .config([providerA, providerB]);
+
+    await p.updateConfig({ alpha: 'A2', beta: 'B2' });
+
+    expect(writesA).toEqual([{ alpha: 'A2' }]);
+    expect(writesB).toEqual([{ beta: 'B2' }]);
+  });
+
+  it('should support updater function via proxy tracking', async () => {
+    const writes: any[] = [];
+    let current: Record<string, any> = { alpha: 'orig', count: 5 };
+    const provider: ConfigurationProvider<any> = {
+      resolve: () => '/root/.config',
+      load: () => current,
+      updateConfig: async (updater) => {
+        const next =
+          typeof updater === 'function'
+            ? await (updater as any)(current)
+            : updater;
+        writes.push(next);
+        current = next;
+      },
+    };
+
+    const p = parser()
+      .option('alpha', { type: 'string' })
+      .option('count', { type: 'number' })
+      .config(provider);
+
+    await p.updateConfig((config) => {
+      config.count = (config as any).count + 1;
+    });
+
+    expect(writes).toHaveLength(1);
+    // Only `count` was set, `alpha` should be untouched from the original
+    expect(writes[0]).toEqual({ alpha: 'orig', count: 6 });
+  });
+});
+
 
 describe('oneOf options', () => {
   it('should parse string value for oneOf [string, boolean]', () => {

--- a/packages/parser/src/lib/parser.ts
+++ b/packages/parser/src/lib/parser.ts
@@ -529,6 +529,19 @@ export class ArgvParser<
    */
   config(provider: ConfigProviderRegistration<TArgs>): this;
   /**
+   * Registers a pre-built configuration provider with framework-level
+   * metadata such as `default`. Use this overload with convenience
+   * factories like {@link ConfigurationProviders.JsonFile} that return a
+   * fully-constructed provider but still need to carry a `default` path.
+   *
+   * @param provider The configuration provider to register.
+   * @param options Framework-level options (e.g. `default`).
+   */
+  config<R extends ConfigProviderRegistration<TArgs>>(
+    provider: R,
+    options: { default?: DefaultConfig<RegistrationLocation<R>> }
+  ): this;
+  /**
    * Registers a configuration provider by class and options.
    * Framework options like `default` are extracted and stored as metadata.
    *
@@ -547,9 +560,11 @@ export class ArgvParser<
     C extends new (opts: any) => ConfigProviderRegistration<TArgs>,
   >(
     providerOrCtor: ConfigProviderRegistration<TArgs> | C,
-    options?: ConstructorParameters<C>[0] & {
-      default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
-    }
+    options?:
+      | { default?: DefaultConfig<any> }
+      | (ConstructorParameters<C>[0] & {
+          default?: DefaultConfig<RegistrationLocation<InstanceType<C>>>;
+        })
   ): this {
     if (typeof providerOrCtor === 'function') {
       if (options === undefined) {
@@ -559,10 +574,15 @@ export class ArgvParser<
       }
 
       // Constructor-based overload: extract framework opts, construct provider
-      const { default: defaultConfig, ...providerOpts } = options;
+      const { default: defaultConfig, ...providerOpts } = options as any;
       const provider = new providerOrCtor(providerOpts);
       this.registerConfigurationProviders(provider, {
         default: defaultConfig,
+      });
+    } else if (options !== undefined) {
+      // Pre-built provider with framework metadata
+      this.registerConfigurationProviders(providerOrCtor, {
+        default: (options as { default?: DefaultConfig<any> }).default,
       });
     } else {
       this.registerConfigurationProviders(providerOrCtor);


### PR DESCRIPTION
## Summary

This PR introduces two major features to cli-forge:

1. **Handler Error Propagation**: Command handlers that throw errors now propagate through a registered error handler chain before re-throwing, allowing custom error handlers to observe and react to handler failures while maintaining backward compatibility with the default error handling behavior.

2. **Configuration Update Support**: Adds `updateConfig()` method to both the CLI and parser, enabling programmatic updates to configuration files with support for partial updates, updater functions with proxy tracking, and intelligent fallback to default paths when no config file exists on disk.

## Key Changes

### Handler Error Propagation
- Introduced `HandlerExecutionError` class that wraps handler exceptions with the original error preserved on the `cause` property
- Handler errors now route through the error handler chain (matching init hook and parse error behavior) before re-throwing
- Default catch-all error handler prints help text and sets `exitCode=1`, preserving existing UX
- Custom error handlers registered via `.errorHandler()` run first in the chain and can distinguish handler failures from framework errors via `instanceof HandlerExecutionError`
- "Missing command" diagnostics (e.g., `demandCommand()`) remain user-facing prompts and don't propagate as handler errors

### Configuration Update Support
- Added `updateConfig(values | updater)` method to CLI and parser for programmatic config file updates
- Supports both object form (partial updates) and function form (read-modify-write with proxy tracking)
- Intelligent fallback to `default` path when no provider resolves from cwd, enabling init-style workflows
- Lazy `default` functions are evaluated at update time
- Multi-provider support: each key routes to its owning provider, with fallback to default paths
- JSON file loader creates parent directories as needed and merges partial updates with existing file contents
- Updater functions receive current config state from the on-disk file (or empty object if creating fresh)
- Strips `extends` metadata from default-path files when loading current state for updaters

### API Additions
- New `.config(provider, { default })` overload for registering pre-built providers with framework metadata
- `updateConfig()` method on both CLI and parser instances
- `HandlerExecutionError` export in public API with `command` and `cause` properties

### Test Coverage
- Comprehensive test suite for handler error propagation including async handlers, nested commands, and error handler chains
- Tests for repeated `forge()` calls on the same CLI instance (commandChain reset)
- Extensive `updateConfig()` tests covering default path fallback, lazy defaults, multi-provider routing, updater functions, and error cases
- Example patterns demonstrating init flows, nested defaults, fresh updaters, and multi-provider fallback scenarios

## Implementation Details

- Handler errors are caught and wrapped before propagating to maintain the error handler chain pattern
- The `AggregateConfigProvider.trackUpdates()` method now intelligently falls back to reading the default-path file when nothing resolves from cwd, enabling read-modify-write updaters to see persisted state
- `commandChain` is reset between `forge()` calls to allow CLI instances to execute multiple commands sequentially
- Error handler chain uses re-throw pattern to allow handlers to pass errors to the next handler in the chain

https://claude.ai/code/session_019aVRTzj72ohUkYFN4ymGQL